### PR TITLE
feat(fdb): client runtime, transaction state machine, and retry reuse

### DIFF
--- a/src/fdb/fdb.cc
+++ b/src/fdb/fdb.cc
@@ -190,12 +190,6 @@ fdb_error_t DB::setNetworkOption(FDBNetworkOption option, std::string_view value
 	return fdb_network_set_option(option, toU8(value), static_cast<int>(value.length()));
 }
 
-fdb_error_t DB::setupNetwork() { return fdb_setup_network(); }
-
-fdb_error_t DB::runNetwork() { return fdb_run_network(); }
-
-fdb_error_t DB::stopNetwork() { return fdb_stop_network(); }
-
 // DB
 
 fdb_error_t DB::setOption(FDBDatabaseOption option, std::string_view value) {

--- a/src/fdb/fdb.cc
+++ b/src/fdb/fdb.cc
@@ -23,6 +23,7 @@
 #include <chrono>
 #include <cstdint>
 #include <iterator>
+#include <limits>
 #include <map>
 #include <memory>
 #include <mutex>
@@ -134,7 +135,60 @@ inline void bumpReadPrefix(const kv::Key &key) {
 	++gReadPrefixHistogram[std::move(tag)];
 }
 
+/// Classifies a failed commit into the state the transaction lands in.
+/// RETRYABLE_NOT_COMMITTED (definitely not applied) allows a replay on this same
+/// transaction. The maybe-committed class, plus transaction_timed_out (1031, whose
+/// outcome during a commit is unknown), is kIndeterminate: nothing may promise the
+/// commit was discarded. Everything else is a plain terminal failure.
+TransactionState classifyCommitFailure(fdb_error_t err) {
+	if (DB::evaluatePredicate(FDB_ERROR_PREDICATE_RETRYABLE_NOT_COMMITTED, err)) {
+		return TransactionState::kRetryPending;
+	}
+	constexpr fdb_error_t kTransactionTimedOut = 1031;
+	if (err == kTransactionTimedOut ||
+	    DB::evaluatePredicate(FDB_ERROR_PREDICATE_MAYBE_COMMITTED, err)) {
+		return TransactionState::kIndeterminate;
+	}
+	return TransactionState::kFailed;
+}
+
 }  // namespace
+
+const char *transactionStateName(TransactionState state) {
+	switch (state) {
+	case TransactionState::kActive:
+		return "Active";
+	case TransactionState::kCommitInFlight:
+		return "CommitInFlight";
+	case TransactionState::kRetryPending:
+		return "RetryPending";
+	case TransactionState::kBackoffInFlight:
+		return "BackoffInFlight";
+	case TransactionState::kIndeterminate:
+		return "Indeterminate";
+	case TransactionState::kCommitted:
+		return "Committed";
+	case TransactionState::kFailed:
+		return "Failed";
+	case TransactionState::kCancelled:
+		return "Cancelled";
+	}
+	return "<unknown>";
+}
+
+namespace detail {
+
+std::array<uint8_t, 8> encodeInt64LE(int64_t value) {
+	std::array<uint8_t, 8> buffer{};
+	auto bits = static_cast<uint64_t>(value);
+	for (auto &byte : buffer) {
+		byte = static_cast<uint8_t>(bits & 0xFF);
+		bits >>= 8;
+	}
+	return buffer;
+}
+
+}  // namespace detail
 
 void setOpCountersEnabled(bool enabled) {
 	gOpCountersEnabled.store(enabled, std::memory_order_relaxed);
@@ -199,20 +253,86 @@ fdb_error_t DB::setOption(FDBDatabaseOption option, std::string_view value) {
 
 // Transaction
 
+void Transaction::requireActive(const char *operation) const {
+	if (state_ == TransactionState::kActive) { return; }
+	throw kv::TransactionStateError(std::string("fdb::Transaction::") + operation +
+	                                ": transaction is not usable in state " +
+	                                transactionStateName(state_));
+}
+
 fdb_error_t Transaction::setOption(FDBTransactionOption option, std::string_view value) {
 	requireHandle("setOption");
+	requireActive("setOption");
+
 	return fdb_transaction_set_option(tr_.get(), option, toU8(value),
 	                                  static_cast<int>(value.length()));
 }
 
 void Transaction::requireHandle(const char *operation) const {
 	if (tr_) { return; }
-	throw std::logic_error(std::string("fdb::Transaction::") + operation +
-	                       ": no backend transaction handle");
+	throw kv::TransactionStateError(std::string("fdb::Transaction::") + operation +
+	                                ": no backend transaction handle");
+}
+
+fdb_error_t Transaction::setIntOption(FDBTransactionOption option, int64_t value) {
+	const auto buffer = detail::encodeInt64LE(value);
+	return fdb_transaction_set_option(tr_.get(), option, buffer.data(),
+	                                  static_cast<int>(buffer.size()));
+}
+
+void Transaction::setMaxRetryDelayMs(int64_t ms) {
+	// [0, INT_MAX] is the range of the int-valued FDB option; a bad value is the
+	// caller's bug, not a backend failure, so it must not reach the backend.
+	if (ms < 0 || ms > std::numeric_limits<int>::max()) {
+		throw std::invalid_argument("fdb::Transaction::setMaxRetryDelayMs: delay out of range");
+	}
+	requireHandle("setMaxRetryDelayMs");
+	requireActive("setMaxRetryDelayMs");
+
+	fdb_error_t err = setIntOption(FDB_TR_OPTION_MAX_RETRY_DELAY, ms);
+	if (err != 0) {
+		// Error-surfaced kFailed like every other throwing path: without the option the
+		// backoff bound is not enforced, so the transaction must not continue as if
+		// nothing happened (reset/cancel stay legal).
+		error_ = err;
+		state_ = TransactionState::kFailed;
+		lastFailureCode_ = err;
+		detail::throwTransactionError(err);
+	}
+	// Remember it: FDB reverts options on reset (but keeps them across on_error), so
+	// reset() must re-apply this one for the retry backoff bound to survive attempts.
+	maxRetryDelayMs_ = ms;
+}
+
+void Transaction::setTimeoutMs(int64_t ms) {
+	// (0, INT_MAX] only: FDB reads 0 as "disable the timeout", the opposite of this method's
+	// bounding purpose, so reject it as a caller bug rather than silently unbound the
+	// transaction. A bad value is the caller's bug and must not reach the backend.
+	if (ms <= 0 || ms > std::numeric_limits<int>::max()) {
+		throw std::invalid_argument(
+		    "fdb::Transaction::setTimeoutMs: timeout must be in (0, INT_MAX]");
+	}
+	requireHandle("setTimeoutMs");
+	requireActive("setTimeoutMs");
+
+	fdb_error_t err = setIntOption(FDB_TR_OPTION_TIMEOUT, ms);
+	if (err != 0) {
+		// Error-surfaced kFailed like every other throwing path: without the option the
+		// transaction runs unbounded, so it must not continue as if nothing happened
+		// (reset/cancel stay legal).
+		error_ = err;
+		state_ = TransactionState::kFailed;
+		lastFailureCode_ = err;
+		detail::throwTransactionError(err);
+	}
+	// Remember it: FDB reverts options on reset (but keeps them across on_error), so
+	// reset() must re-apply this one for the time bound to survive attempts.
+	timeoutMs_ = ms;
 }
 
 std::optional<kv::Value> Transaction::get(const kv::Key &key, bool snapshot) {
 	requireHandle("get");
+	requireActive("get");
 
 	bump(gOpCounters.pointReads);
 	bumpReadPrefix(key);
@@ -223,6 +343,9 @@ std::optional<kv::Value> Transaction::get(const kv::Key &key, bool snapshot) {
 		fdb_error_t injected = FaultInjection::next(faultInjection_->readErrors);
 		if (injected != 0) {
 			error_ = injected;
+			state_ = detail::isRetryableReadError(injected) ? TransactionState::kRetryPending
+			                                                : TransactionState::kFailed;
+			lastFailureCode_ = injected;
 			safs::log_err("Transaction::get: injected error: {}", fdb_get_error(injected));
 			detail::throwTransactionError(injected);
 		}
@@ -238,6 +361,9 @@ std::optional<kv::Value> Transaction::get(const kv::Key &key, bool snapshot) {
 	if (profiling) { addNanos(gOpCounters.readWaitNanos, elapsedNanosSince(waitStart)); }
 
 	if (error_ != 0) {
+		state_ = detail::isRetryableReadError(error_) ? TransactionState::kRetryPending
+		                                              : TransactionState::kFailed;
+		lastFailureCode_ = error_;
 		safs::log_err("Transaction::get: fdb_future_block_until_ready: error: {}",
 		              fdb_get_error(error_));
 		detail::throwTransactionError(error_);
@@ -250,6 +376,9 @@ std::optional<kv::Value> Transaction::get(const kv::Key &key, bool snapshot) {
 	error_ = fdb_future_get_value(future.get(), &valuePresent, &valueRead, &valueLength);
 
 	if (error_ != 0) {
+		state_ = detail::isRetryableReadError(error_) ? TransactionState::kRetryPending
+		                                              : TransactionState::kFailed;
+		lastFailureCode_ = error_;
 		safs::log_err("Transaction::get: fdb_future_get_value: error: {}", fdb_get_error(error_));
 		detail::throwTransactionError(error_);
 	}
@@ -264,13 +393,16 @@ std::optional<kv::Value> Transaction::get(const kv::Key &key, bool snapshot) {
 
 std::unique_ptr<kv::IFuture> Transaction::getAsync(const kv::Key &key, bool snapshot) {
 	requireHandle("getAsync");
+	requireActive("getAsync");
 
 	bump(gOpCounters.pointReads);
 	bumpReadPrefix(key);
 	FDBFuture *future = fdb_transaction_get(tr_.get(), key.data(), static_cast<int>(key.size()),
 	                                        static_cast<fdb_bool_t>(snapshot));
 
-	return std::make_unique<FDBFutureValue>(future, faultInjection_);
+	return std::make_unique<FDBFutureValue>(
+	    future, faultInjection_,
+	    ReadFailureSink{&state_, &lastFailureCode_, &attemptGeneration_, attemptGeneration_});
 }
 
 kv::GetRangeResult Transaction::getRange(
@@ -287,6 +419,7 @@ std::unique_ptr<kv::IRangeFuture> Transaction::getRangeAsync(
     bool snapshot /* = false */, bool reverse /* = false */,
     FDBStreamingMode streamingMode /* = FDB_STREAMING_MODE_SERIAL */) {
 	requireHandle("getRangeAsync");
+	requireActive("getRangeAsync");
 
 	bump(gOpCounters.rangeReads);
 	bumpReadPrefix(begin.getKey());
@@ -310,11 +443,14 @@ std::unique_ptr<kv::IRangeFuture> Transaction::getRangeAsync(
 	    endOffset, limit, kBytesLimit, streamingMode, iteration, static_cast<fdb_bool_t>(snapshot),
 	    static_cast<fdb_bool_t>(reverse));
 
-	return std::make_unique<FDBFutureRange>(future, faultInjection_);
+	return std::make_unique<FDBFutureRange>(
+	    future, faultInjection_,
+	    ReadFailureSink{&state_, &lastFailureCode_, &attemptGeneration_, attemptGeneration_});
 }
 
 void Transaction::set(const kv::Key &key, const kv::Value &value) {
 	requireHandle("set");
+	requireActive("set");
 
 	bump(gOpCounters.sets);
 	fdb_transaction_set(tr_.get(), key.data(), static_cast<int>(key.size()), value.data(),
@@ -323,6 +459,7 @@ void Transaction::set(const kv::Key &key, const kv::Value &value) {
 
 void Transaction::atomicAdd(const kv::Key &key, const kv::Value &delta) {
 	requireHandle("atomicAdd");
+	requireActive("atomicAdd");
 
 	bump(gOpCounters.atomicAdds);
 	fdb_transaction_atomic_op(tr_.get(), key.data(), static_cast<int>(key.size()), delta.data(),
@@ -331,6 +468,7 @@ void Transaction::atomicAdd(const kv::Key &key, const kv::Value &delta) {
 
 void Transaction::atomicMax(const kv::Key &key, const kv::Value &value) {
 	requireHandle("atomicMax");
+	requireActive("atomicMax");
 
 	// Counted under atomicAdds is wrong, and adding a positional counter field would
 	// desync the FdbOpCounters snapshot init; atomicMax is profiling-irrelevant, so it
@@ -341,6 +479,7 @@ void Transaction::atomicMax(const kv::Key &key, const kv::Value &value) {
 
 void Transaction::remove(const kv::Key &key) {
 	requireHandle("remove");
+	requireActive("remove");
 
 	bump(gOpCounters.clears);
 	fdb_transaction_clear(tr_.get(), key.data(), static_cast<int>(key.size()));
@@ -348,6 +487,7 @@ void Transaction::remove(const kv::Key &key) {
 
 void Transaction::removeRange(const kv::Key &start, const kv::Key &end) {
 	requireHandle("removeRange");
+	requireActive("removeRange");
 
 	bump(gOpCounters.clearRanges);
 	fdb_transaction_clear_range(tr_.get(), start.data(), static_cast<int>(start.size()), end.data(),
@@ -356,6 +496,10 @@ void Transaction::removeRange(const kv::Key &start, const kv::Key &end) {
 
 void Transaction::addReadConflictKey(const kv::Key &key) {
 	requireHandle("addReadConflictKey");
+	// A read-conflict annotation is a read into the attempt's conflict footprint, so it
+	// obeys the same lifecycle as every other data op: only valid on the live attempt,
+	// never once a failure or commit has moved the transaction on.
+	requireActive("addReadConflictKey");
 
 	// FDB conflict ranges are half-open; a single key is [key, key + '\0').
 	kv::Key end = key;
@@ -366,6 +510,10 @@ void Transaction::addReadConflictKey(const kv::Key &key) {
 	if (err != 0) {
 		// add_conflict_range is a synchronous client call; a failure is local misuse,
 		// not a backend read failure, and must not silently drop the caller's protection.
+		// Hence invalid_argument (a std::logic_error): the master op-retry catch lets it
+		// escape to fail-stop, not mask as EIO. Safe only because the sole caller passes
+		// well-formed keys; retype to kv::TransactionError if this ever takes an untrusted
+		// or variable-length key, so a data-dependent rejection fails just the op.
 		safs::log_err("Transaction::addReadConflictKey: error: {}", fdb_get_error(err));
 		throw std::invalid_argument("fdb::Transaction::addReadConflictKey: " +
 		                            std::string(fdb_get_error(err)));
@@ -374,6 +522,7 @@ void Transaction::addReadConflictKey(const kv::Key &key) {
 
 bool Transaction::commit() {
 	requireHandle("commit");
+	requireActive("commit");
 
 	// A new attempt invalidates the previous attempt's version: a failed re-commit on a
 	// reused transaction must not leave a stale success visible via getCommittedVersion.
@@ -387,6 +536,8 @@ bool Transaction::commit() {
 		fdb_error_t injected = FaultInjection::next(faultInjection_->preCommitErrors);
 		if (injected != 0) {
 			error_ = injected;
+			state_ = classifyCommitFailure(injected);
+			lastFailureCode_ = injected;
 			safs::log_err("Transaction::commit: injected pre-commit error: {}",
 			              fdb_get_error(injected));
 			countFailedCommit(injected);
@@ -402,7 +553,17 @@ bool Transaction::commit() {
 	error_ = fdb_future_block_until_ready(future.get());
 	if (profiling) { addNanos(gOpCounters.commitWaitNanos, elapsedNanosSince(waitStart)); }
 
+	// TEST-ONLY scripted wait-layer failure (see FaultInjection::commitWaitErrors).
+	if (error_ == 0 && faultInjection_ != nullptr) {
+		error_ = FaultInjection::next(faultInjection_->commitWaitErrors);
+	}
+
 	if (error_ != 0) {
+		// The commit was already submitted; a wait-layer failure means its outcome is
+		// UNKNOWN. Force kIndeterminate (never retryable): replaying a commit that actually
+		// landed would double-apply it.
+		state_ = TransactionState::kIndeterminate;
+		lastFailureCode_ = error_;
 		safs::log_err("Transaction::commit: fdb_future_block_until_ready: error: {}",
 		              fdb_get_error(error_));
 		countFailedCommit(error_);
@@ -422,10 +583,14 @@ bool Transaction::commit() {
 	}
 
 	if (error_ != 0) {
+		state_ = classifyCommitFailure(error_);
+		lastFailureCode_ = error_;
 		safs::log_err("Transaction::commit: commit failed: {}", fdb_get_error(error_));
 		countFailedCommit(error_);
 		return false;
 	}
+
+	state_ = TransactionState::kCommitted;
 
 	int64_t version{};
 	fdb_error_t versionError = fdb_transaction_get_committed_version(tr_.get(), &version);
@@ -453,7 +618,10 @@ bool Transaction::commit() {
 }
 
 std::optional<uint64_t> Transaction::getApproximateSize() const {
-	if (!tr_) { return std::nullopt; }
+	// Requires kActive like every other operation, but as a diagnostic query it reports
+	// "no estimate" instead of throwing: the estimate is meaningless once a commit
+	// started, and in-flight states are owned by their futures.
+	if (!tr_ || state_ != TransactionState::kActive) { return std::nullopt; }
 
 	// This is an advisory query: on failure we return std::nullopt and let the caller fall back
 	// to a count-based bound. Errors are kept in a local variable rather than the member error_,
@@ -477,7 +645,126 @@ std::optional<uint64_t> Transaction::getApproximateSize() const {
 	return static_cast<uint64_t>(size);
 }
 
+void Transaction::reset() {
+	requireHandle("reset");
+	switch (state_) {
+	case TransactionState::kActive:
+	case TransactionState::kRetryPending:
+	case TransactionState::kCommitted:
+	case TransactionState::kCancelled:
+		break;
+	case TransactionState::kFailed:
+		if (backoffAbandoned_) {
+			// The abandoned on_error's outcome is unknown and FDB leaves a reset
+			// concurrent with an in-flight on_error undefined; destroy instead.
+			throw kv::TransactionStateError(
+			    "fdb::Transaction::reset: forbidden after abandoning a backoff future");
+		}
+		break;
+	case TransactionState::kCommitInFlight:
+	case TransactionState::kBackoffInFlight:
+	case TransactionState::kIndeterminate:
+		// In-flight futures own the handle; and a maybe-committed transaction must
+		// never be replayed on a reused object.
+		throw kv::TransactionStateError(
+		    std::string("fdb::Transaction::reset: forbidden in state ") +
+		    transactionStateName(state_));
+	}
+
+	fdb_transaction_reset(tr_.get());
+	error_ = 0;
+	lastFailureCode_ = 0;
+	committedVersion_.reset();
+	// A fresh attempt begins: retire any read future still holding the prior generation
+	// so its late failure cannot land on this attempt (see recordReadFailure).
+	++attemptGeneration_;
+	state_ = TransactionState::kActive;
+	// FDB reverts all options on reset; re-apply the sticky ones we promised persist.
+	if (maxRetryDelayMs_.has_value()) {
+		fdb_error_t err = setIntOption(FDB_TR_OPTION_MAX_RETRY_DELAY, *maxRetryDelayMs_);
+		if (err != 0) {
+			// The handle was reset but the promised option is gone; unusable.
+			error_ = err;
+			state_ = TransactionState::kFailed;
+			lastFailureCode_ = err;
+			detail::throwTransactionError(err);
+		}
+	}
+	if (timeoutMs_.has_value()) {
+		fdb_error_t err = setIntOption(FDB_TR_OPTION_TIMEOUT, *timeoutMs_);
+		if (err != 0) {
+			// The handle was reset but the promised time bound is gone; unusable.
+			error_ = err;
+			state_ = TransactionState::kFailed;
+			lastFailureCode_ = err;
+			detail::throwTransactionError(err);
+		}
+	}
+}
+
+void Transaction::cancel() {
+	requireHandle("cancel");
+	switch (state_) {
+	case TransactionState::kActive:
+	case TransactionState::kRetryPending:
+		break;
+	case TransactionState::kFailed:
+		if (backoffAbandoned_) {
+			throw kv::TransactionStateError(
+			    "fdb::Transaction::cancel: forbidden after abandoning a backoff future");
+		}
+		break;
+	case TransactionState::kCommitInFlight:
+	case TransactionState::kBackoffInFlight:
+	case TransactionState::kIndeterminate:
+	case TransactionState::kCommitted:
+	case TransactionState::kCancelled:
+		// Cancelling an in-flight commit has an unpredictable outcome per the C API;
+		// abandon the commit future instead (lands in kIndeterminate).
+		throw kv::TransactionStateError(
+		    std::string("fdb::Transaction::cancel: forbidden in state ") +
+		    transactionStateName(state_));
+	}
+
+	fdb_transaction_cancel(tr_.get());
+	constexpr fdb_error_t kTransactionCancelled = 1025;
+	error_ = kTransactionCancelled;
+	state_ = TransactionState::kCancelled;
+	lastFailureCode_ = kTransactionCancelled;
+}
+
 namespace {
+
+/// Owns the wakeup target across a future's lifetime so the FDB network thread
+/// never touches the (possibly freed) future wrapper. Freed by fireReadyNode().
+struct ReadyNode {
+	void (*callback)(void *);
+	void *arg;
+};
+
+void fireReadyNode(FDBFuture * /*future*/, void *param) {
+	std::unique_ptr<ReadyNode> node(static_cast<ReadyNode *>(param));
+	if (node->callback != nullptr) { node->callback(node->arg); }
+}
+
+/// Arms a one-shot ready callback on an FDB future. Routes the wakeup through a
+/// heap node rather than the wrapper object: the event-loop thread may destroy the
+/// wrapper (after observing isReady()) concurrently with the FDB network thread
+/// firing the callback, so the callback must not dereference the wrapper. The node
+/// never leaks: fdb_c fires the callback exactly once even when the future is
+/// destroyed before becoming ready (destroy cancels it, cancellation makes it
+/// ready), pinned by DestroyingArmedUnreadyFutureFiresCallback in fdb_unittest.cc;
+/// a spurious late wakeup write is harmless.
+void armReadyCallback(FDBFuture *future, void (*callback)(void *), void *arg, const char *who) {
+	auto *node = new ReadyNode{callback, arg};
+	fdb_error_t err = fdb_future_set_callback(future, &fireReadyNode, node);
+	if (err != 0) {
+		// Wakeup not armed; the caller's poll loop still finalizes at its normal
+		// cadence, just without the immediate wakeup.
+		delete node;
+		safs::log_warn("{}: fdb_future_set_callback: {}", who, fdb_get_error(err));
+	}
+}
 
 /// Pollable wrapper around an in-flight fdb_transaction_commit() future.
 /// Mirrors Transaction::commit()'s outcome handling (error mapping, conflict vs
@@ -488,15 +775,25 @@ class FDBCommitFuture final : public kv::ICommitFuture {
 public:
 	FDBCommitFuture(FDBFuture *commitFuture, FDBTransaction *trHandle,
 	                std::optional<int64_t> *committedVersionOut, fdb_error_t *errorOut,
+	                TransactionState *stateOut, fdb_error_t *lastFailureCodeOut,
 	                FaultInjection *fault)
 	    : future_(commitFuture),
 	      trHandle_(trHandle),
 	      committedVersionOut_(committedVersionOut),
 	      errorOut_(errorOut),
+	      stateOut_(stateOut),
+	      lastFailureCodeOut_(lastFailureCodeOut),
 	      faultInjection_(fault) {}
 
 	~FDBCommitFuture() override {
-		if (future_ != nullptr) { fdb_future_destroy(future_); }
+		if (future_ == nullptr) { return; }
+		if (!consumed_) {
+			// Abandoned in-flight commit (e.g. shutdown): the commit may have applied,
+			// so nothing may promise it was discarded.
+			*stateOut_ = TransactionState::kIndeterminate;
+			fdb_future_cancel(future_);
+		}
+		fdb_future_destroy(future_);
 	}
 
 	FDBCommitFuture(const FDBCommitFuture &) = delete;
@@ -516,22 +813,7 @@ public:
 			callback(arg);
 			return;
 		}
-		// Route the wakeup through a heap node rather than `this`: the event-loop
-		// thread may destroy this future (after observing isReady()) concurrently
-		// with the FDB network thread firing the callback, so the callback must not
-		// dereference the future. The node owns only a plain function pointer and
-		// arg and is freed by the callback. If this future is destroyed before the
-		// commit ever becomes ready, the callback never fires and the node leaks
-		// once: a bounded, one-time leak per such future, which is harmless.
-		auto *node = new ReadyNode{callback, arg};
-		fdb_error_t err = fdb_future_set_callback(future_, &FDBCommitFuture::onReady, node);
-		if (err != 0) {
-			// Wakeup not armed; the caller's poll loop still finalizes this commit
-			// at its normal cadence, just without the immediate wakeup.
-			delete node;
-			safs::log_warn("FDBCommitFuture::setReadyCallback: fdb_future_set_callback: {}",
-			               fdb_get_error(err));
-		}
+		armReadyCallback(future_, callback, arg, "FDBCommitFuture::setReadyCallback");
 	}
 
 	bool getResult(int *error, bool *retryable) override {
@@ -553,9 +835,30 @@ public:
 		const bool profiling = opCountersEnabled();
 		const auto waitStart =
 		    profiling ? std::chrono::steady_clock::now() : std::chrono::steady_clock::time_point{};
-		fdb_error_t err = fdb_future_block_until_ready(future_);
+		fdb_error_t waitErr = fdb_future_block_until_ready(future_);
 		if (profiling) { addNanos(gOpCounters.commitWaitNanos, elapsedNanosSince(waitStart)); }
-		if (err == 0) { err = fdb_future_get_error(future_); }
+		// TEST-ONLY scripted wait-layer failure (see FaultInjection::commitWaitErrors).
+		if (waitErr == 0 && faultInjection_ != nullptr) {
+			waitErr = FaultInjection::next(faultInjection_->commitWaitErrors);
+		}
+		if (waitErr != 0) {
+			// Wait-layer failure after commit submission: outcome UNKNOWN, so kIndeterminate
+			// and never retryable (see Transaction::commit() for the double-apply rationale).
+			*errorOut_ = waitErr;
+			*stateOut_ = TransactionState::kIndeterminate;
+			*lastFailureCodeOut_ = waitErr;
+			consumedError_ = waitErr;
+			consumedRetryable_ = false;
+			safs::log_err("FDBCommitFuture::getResult: fdb_future_block_until_ready: error: {}",
+			              fdb_get_error(waitErr));
+			if (opCountersEnabled()) {
+				gOpCounters.commitFailures.fetch_add(1, std::memory_order_relaxed);
+			}
+			if (error != nullptr) { *error = waitErr; }
+			if (retryable != nullptr) { *retryable = false; }
+			return false;
+		}
+		fdb_error_t err = fdb_future_get_error(future_);
 
 		// TEST-ONLY scripted post-commit override: at this point the commit IS durable;
 		// the caller is nevertheless told it failed with the scripted code
@@ -566,6 +869,8 @@ public:
 
 		if (err != 0) {
 			*errorOut_ = err;
+			*stateOut_ = classifyCommitFailure(err);
+			*lastFailureCodeOut_ = err;
 			consumedError_ = err;
 			// RETRYABLE_NOT_COMMITTED, NOT the broad RETRYABLE predicate: RETRYABLE also
 			// returns true for commit_unknown_result (1021) and the rest of the
@@ -587,6 +892,8 @@ public:
 			if (retryable != nullptr) { *retryable = isRetryable; }
 			return false;
 		}
+
+		*stateOut_ = TransactionState::kCommitted;
 
 		int64_t version{};
 		fdb_error_t versionError = fdb_transaction_get_committed_version(trHandle_, &version);
@@ -617,22 +924,12 @@ public:
 	}
 
 private:
-	/// Owns the wakeup target across the future's lifetime so the FDB network
-	/// thread never touches the (possibly freed) future. Freed by onReady().
-	struct ReadyNode {
-		void (*callback)(void *);
-		void *arg;
-	};
-
-	static void onReady(FDBFuture * /*future*/, void *param) {
-		std::unique_ptr<ReadyNode> node(static_cast<ReadyNode *>(param));
-		if (node->callback != nullptr) { node->callback(node->arg); }
-	}
-
 	FDBFuture *future_;
 	FDBTransaction *trHandle_;
 	std::optional<int64_t> *committedVersionOut_;
 	fdb_error_t *errorOut_;
+	TransactionState *stateOut_;
+	fdb_error_t *lastFailureCodeOut_;
 	FaultInjection *faultInjection_;
 	bool consumed_ = false;
 	fdb_error_t consumedError_ = 0;
@@ -644,7 +941,20 @@ private:
 /// a real failed commit, but nothing was submitted to the cluster.
 class InjectedCommitFuture final : public kv::ICommitFuture {
 public:
-	explicit InjectedCommitFuture(fdb_error_t err) : error_(err) {}
+	InjectedCommitFuture(fdb_error_t err, TransactionState *stateOut,
+	                     fdb_error_t *lastFailureCodeOut)
+	    : error_(err), stateOut_(stateOut), lastFailureCodeOut_(lastFailureCodeOut) {}
+
+	~InjectedCommitFuture() override {
+		// Mirror the real commit future's abandonment rule so tests exercise the
+		// same owner-state transitions.
+		if (!consumed_) { *stateOut_ = TransactionState::kIndeterminate; }
+	}
+
+	InjectedCommitFuture(const InjectedCommitFuture &) = delete;
+	InjectedCommitFuture &operator=(const InjectedCommitFuture &) = delete;
+	InjectedCommitFuture(InjectedCommitFuture &&) = delete;
+	InjectedCommitFuture &operator=(InjectedCommitFuture &&) = delete;
 
 	bool isReady() override { return true; }
 
@@ -659,12 +969,103 @@ public:
 		if (retryable != nullptr) { *retryable = isRetryable; }
 		if (consumed_) { return false; }
 		consumed_ = true;
+		*stateOut_ = classifyCommitFailure(error_);
+		*lastFailureCodeOut_ = error_;
 		countFailedCommit(error_);
 		return false;
 	}
 
 private:
 	fdb_error_t error_;
+	TransactionState *stateOut_;
+	fdb_error_t *lastFailureCodeOut_;
+	bool consumed_ = false;
+};
+
+/// Pollable wrapper around an in-flight fdb_transaction_on_error() future (the
+/// wrapper half of the retry architecture; the retry policy lives in the caller).
+/// The back-pointers reference the owning Transaction's members, so that Transaction
+/// must outlive this future.
+class FDBVoidFuture final : public kv::IVoidFuture {
+public:
+	FDBVoidFuture(FDBFuture *future, fdb_error_t *errorOut,
+	              std::optional<int64_t> *committedVersionOut, TransactionState *stateOut,
+	              fdb_error_t *lastFailureCodeOut, bool *backoffAbandonedOut,
+	              uint64_t *attemptGenerationOut)
+	    : future_(future),
+	      errorOut_(errorOut),
+	      committedVersionOut_(committedVersionOut),
+	      stateOut_(stateOut),
+	      lastFailureCodeOut_(lastFailureCodeOut),
+	      backoffAbandonedOut_(backoffAbandonedOut),
+	      attemptGenerationOut_(attemptGenerationOut) {}
+
+	~FDBVoidFuture() override {
+		if (future_ == nullptr) { return; }
+		if (!consumed_) {
+			// Abandoned recovery: its outcome is unknown, so the transaction cannot
+			// be reused, and reset-during-on_error is undefined in FDB. Terminal,
+			// destroy-only (Transaction::reset checks the flag).
+			*stateOut_ = TransactionState::kFailed;
+			*backoffAbandonedOut_ = true;
+			fdb_future_cancel(future_);
+		}
+		fdb_future_destroy(future_);
+	}
+
+	FDBVoidFuture(const FDBVoidFuture &) = delete;
+	FDBVoidFuture &operator=(const FDBVoidFuture &) = delete;
+	FDBVoidFuture(FDBVoidFuture &&) = delete;
+	FDBVoidFuture &operator=(FDBVoidFuture &&) = delete;
+
+	bool isReady() override { return fdb_future_is_ready(future_) != 0; }
+
+	void setReadyCallback(void (*callback)(void *), void *arg) override {
+		if (callback == nullptr) { return; }
+		armReadyCallback(future_, callback, arg, "FDBVoidFuture::setReadyCallback");
+	}
+
+	void get() override {
+		if (consumed_) {
+			throw kv::TransactionStateError("FDBVoidFuture::get: future already consumed");
+		}
+		consumed_ = true;
+
+		fdb_error_t err = fdb_future_block_until_ready(future_);
+		if (err == 0) { err = fdb_future_get_error(future_); }
+
+		if (err != 0) {
+			// Recovery failed: terminal and destroy-only. backoffAbandoned_ forbids reset()
+			// (the outcome is unknown, and reset during/after a failed on_error is undefined
+			// in FDB); the caller must build a fresh transaction. The thrown type still
+			// classifies the error (retryable here means "retry on a FRESH transaction").
+			*errorOut_ = err;
+			*stateOut_ = TransactionState::kFailed;
+			*lastFailureCodeOut_ = err;
+			*backoffAbandonedOut_ = true;
+			safs::log_err("FDBVoidFuture::get: on_error failed: {}", fdb_get_error(err));
+			detail::throwTransactionError(err);
+		}
+
+		// Recovery complete: the SAME handle is ready for a fresh attempt, with
+		// FDB's accumulated backoff already applied by the resolved future. Bump the
+		// attempt generation so a read future from the failed attempt cannot record its
+		// late failure into this one (see recordReadFailure).
+		*errorOut_ = 0;
+		*lastFailureCodeOut_ = 0;
+		committedVersionOut_->reset();
+		++(*attemptGenerationOut_);
+		*stateOut_ = TransactionState::kActive;
+	}
+
+private:
+	FDBFuture *future_;
+	fdb_error_t *errorOut_;
+	std::optional<int64_t> *committedVersionOut_;
+	TransactionState *stateOut_;
+	fdb_error_t *lastFailureCodeOut_;
+	bool *backoffAbandonedOut_;
+	uint64_t *attemptGenerationOut_;
 	bool consumed_ = false;
 };
 
@@ -672,12 +1073,14 @@ private:
 
 std::unique_ptr<kv::ICommitFuture> Transaction::commitAsync() {
 	requireHandle("commitAsync");
+	requireActive("commitAsync");
 
 	// A new attempt invalidates the previous attempt's version: a failed re-commit on a
 	// reused transaction must not leave a stale success visible via getCommittedVersion.
 	committedVersion_.reset();
 
 	bump(gOpCounters.commits);
+	state_ = TransactionState::kCommitInFlight;
 
 	// TEST-ONLY scripted pre-commit failure: nothing is submitted to the cluster.
 	if (faultInjection_ != nullptr) {
@@ -686,14 +1089,38 @@ std::unique_ptr<kv::ICommitFuture> Transaction::commitAsync() {
 			error_ = injected;
 			safs::log_err("Transaction::commitAsync: injected pre-commit error: {}",
 			              fdb_get_error(injected));
-			return std::make_unique<InjectedCommitFuture>(injected);
+			return std::make_unique<InjectedCommitFuture>(injected, &state_, &lastFailureCode_);
 		}
 	}
 
 	FDBFuture *future = fdb_transaction_commit(tr_.get());
 
 	return std::make_unique<FDBCommitFuture>(future, tr_.get(), &committedVersion_, &error_,
-	                                         faultInjection_);
+	                                         &state_, &lastFailureCode_, faultInjection_);
+}
+
+std::unique_ptr<kv::IVoidFuture> Transaction::onErrorAsync(fdb_error_t err) {
+	if (err == 0) { throw std::invalid_argument("fdb::Transaction::onErrorAsync: error code 0"); }
+	requireHandle("onErrorAsync");
+	if (state_ != TransactionState::kRetryPending) {
+		throw kv::TransactionStateError(
+		    std::string("fdb::Transaction::onErrorAsync: transaction is not usable in state ") +
+		    transactionStateName(state_));
+	}
+	// The code drives FDB's retry classification and backoff, so it must be the failure
+	// THIS transaction recorded, not one observed on some other transaction.
+	if (err != lastFailureCode_) {
+		throw std::invalid_argument(
+		    "fdb::Transaction::onErrorAsync: error code " + std::to_string(err) +
+		    " does not match this transaction's failure " + std::to_string(lastFailureCode_));
+	}
+
+	state_ = TransactionState::kBackoffInFlight;
+	FDBFuture *future = fdb_transaction_on_error(tr_.get(), err);
+
+	return std::make_unique<FDBVoidFuture>(future, &error_, &committedVersion_, &state_,
+	                                       &lastFailureCode_, &backoffAbandoned_,
+	                                       &attemptGeneration_);
 }
 
 }  // namespace fdb

--- a/src/fdb/fdb.cc
+++ b/src/fdb/fdb.cc
@@ -22,6 +22,7 @@
 #include <atomic>
 #include <chrono>
 #include <cstdint>
+#include <exception>
 #include <iterator>
 #include <limits>
 #include <map>
@@ -254,14 +255,19 @@ fdb_error_t DB::setOption(FDBDatabaseOption option, std::string_view value) {
 // Transaction
 
 void Transaction::requireActive(const char *operation) const {
+	requireHandle(operation);
 	if (state_ == TransactionState::kActive) { return; }
 	throw kv::TransactionStateError(std::string("fdb::Transaction::") + operation +
 	                                ": transaction is not usable in state " +
 	                                transactionStateName(state_));
 }
 
+void Transaction::recordFailure(TransactionState failureState, fdb_error_t error) {
+	state_ = failureState;
+	lastFailureCode_ = error;
+}
+
 fdb_error_t Transaction::setOption(FDBTransactionOption option, std::string_view value) {
-	requireHandle("setOption");
 	requireActive("setOption");
 
 	return fdb_transaction_set_option(tr_.get(), option, toU8(value),
@@ -286,7 +292,6 @@ void Transaction::setMaxRetryDelayMs(int64_t ms) {
 	if (ms < 0 || ms > std::numeric_limits<int>::max()) {
 		throw std::invalid_argument("fdb::Transaction::setMaxRetryDelayMs: delay out of range");
 	}
-	requireHandle("setMaxRetryDelayMs");
 	requireActive("setMaxRetryDelayMs");
 
 	fdb_error_t err = setIntOption(FDB_TR_OPTION_MAX_RETRY_DELAY, ms);
@@ -295,8 +300,7 @@ void Transaction::setMaxRetryDelayMs(int64_t ms) {
 		// backoff bound is not enforced, so the transaction must not continue as if
 		// nothing happened (reset/cancel stay legal).
 		error_ = err;
-		state_ = TransactionState::kFailed;
-		lastFailureCode_ = err;
+		recordFailure(TransactionState::kFailed, err);
 		detail::throwTransactionError(err);
 	}
 	// Remember it: FDB reverts options on reset (but keeps them across on_error), so
@@ -312,7 +316,6 @@ void Transaction::setTimeoutMs(int64_t ms) {
 		throw std::invalid_argument(
 		    "fdb::Transaction::setTimeoutMs: timeout must be in (0, INT_MAX]");
 	}
-	requireHandle("setTimeoutMs");
 	requireActive("setTimeoutMs");
 
 	fdb_error_t err = setIntOption(FDB_TR_OPTION_TIMEOUT, ms);
@@ -321,8 +324,7 @@ void Transaction::setTimeoutMs(int64_t ms) {
 		// transaction runs unbounded, so it must not continue as if nothing happened
 		// (reset/cancel stay legal).
 		error_ = err;
-		state_ = TransactionState::kFailed;
-		lastFailureCode_ = err;
+		recordFailure(TransactionState::kFailed, err);
 		detail::throwTransactionError(err);
 	}
 	// Remember it: FDB reverts options on reset (but keeps them across on_error), so
@@ -331,7 +333,6 @@ void Transaction::setTimeoutMs(int64_t ms) {
 }
 
 std::optional<kv::Value> Transaction::get(const kv::Key &key, bool snapshot) {
-	requireHandle("get");
 	requireActive("get");
 
 	bump(gOpCounters.pointReads);
@@ -343,9 +344,9 @@ std::optional<kv::Value> Transaction::get(const kv::Key &key, bool snapshot) {
 		fdb_error_t injected = FaultInjection::next(faultInjection_->readErrors);
 		if (injected != 0) {
 			error_ = injected;
-			state_ = detail::isRetryableReadError(injected) ? TransactionState::kRetryPending
-			                                                : TransactionState::kFailed;
-			lastFailureCode_ = injected;
+			recordFailure(detail::isRetryableReadError(injected) ? TransactionState::kRetryPending
+			                                                     : TransactionState::kFailed,
+			              injected);
 			safs::log_err("Transaction::get: injected error: {}", fdb_get_error(injected));
 			detail::throwTransactionError(injected);
 		}
@@ -361,9 +362,9 @@ std::optional<kv::Value> Transaction::get(const kv::Key &key, bool snapshot) {
 	if (profiling) { addNanos(gOpCounters.readWaitNanos, elapsedNanosSince(waitStart)); }
 
 	if (error_ != 0) {
-		state_ = detail::isRetryableReadError(error_) ? TransactionState::kRetryPending
-		                                              : TransactionState::kFailed;
-		lastFailureCode_ = error_;
+		recordFailure(detail::isRetryableReadError(error_) ? TransactionState::kRetryPending
+		                                                   : TransactionState::kFailed,
+		              error_);
 		safs::log_err("Transaction::get: fdb_future_block_until_ready: error: {}",
 		              fdb_get_error(error_));
 		detail::throwTransactionError(error_);
@@ -376,9 +377,9 @@ std::optional<kv::Value> Transaction::get(const kv::Key &key, bool snapshot) {
 	error_ = fdb_future_get_value(future.get(), &valuePresent, &valueRead, &valueLength);
 
 	if (error_ != 0) {
-		state_ = detail::isRetryableReadError(error_) ? TransactionState::kRetryPending
-		                                              : TransactionState::kFailed;
-		lastFailureCode_ = error_;
+		recordFailure(detail::isRetryableReadError(error_) ? TransactionState::kRetryPending
+		                                                   : TransactionState::kFailed,
+		              error_);
 		safs::log_err("Transaction::get: fdb_future_get_value: error: {}", fdb_get_error(error_));
 		detail::throwTransactionError(error_);
 	}
@@ -392,7 +393,6 @@ std::optional<kv::Value> Transaction::get(const kv::Key &key, bool snapshot) {
 }
 
 std::unique_ptr<kv::IFuture> Transaction::getAsync(const kv::Key &key, bool snapshot) {
-	requireHandle("getAsync");
 	requireActive("getAsync");
 
 	bump(gOpCounters.pointReads);
@@ -418,7 +418,6 @@ std::unique_ptr<kv::IRangeFuture> Transaction::getRangeAsync(
     const kv::KeySelector &begin, const kv::KeySelector &end, int limit, int iteration /* = 0 */,
     bool snapshot /* = false */, bool reverse /* = false */,
     FDBStreamingMode streamingMode /* = FDB_STREAMING_MODE_SERIAL */) {
-	requireHandle("getRangeAsync");
 	requireActive("getRangeAsync");
 
 	bump(gOpCounters.rangeReads);
@@ -449,7 +448,6 @@ std::unique_ptr<kv::IRangeFuture> Transaction::getRangeAsync(
 }
 
 void Transaction::set(const kv::Key &key, const kv::Value &value) {
-	requireHandle("set");
 	requireActive("set");
 
 	bump(gOpCounters.sets);
@@ -458,7 +456,6 @@ void Transaction::set(const kv::Key &key, const kv::Value &value) {
 }
 
 void Transaction::atomicAdd(const kv::Key &key, const kv::Value &delta) {
-	requireHandle("atomicAdd");
 	requireActive("atomicAdd");
 
 	bump(gOpCounters.atomicAdds);
@@ -467,7 +464,6 @@ void Transaction::atomicAdd(const kv::Key &key, const kv::Value &delta) {
 }
 
 void Transaction::atomicMax(const kv::Key &key, const kv::Value &value) {
-	requireHandle("atomicMax");
 	requireActive("atomicMax");
 
 	// Counted under atomicAdds is wrong, and adding a positional counter field would
@@ -478,7 +474,6 @@ void Transaction::atomicMax(const kv::Key &key, const kv::Value &value) {
 }
 
 void Transaction::remove(const kv::Key &key) {
-	requireHandle("remove");
 	requireActive("remove");
 
 	bump(gOpCounters.clears);
@@ -486,7 +481,6 @@ void Transaction::remove(const kv::Key &key) {
 }
 
 void Transaction::removeRange(const kv::Key &start, const kv::Key &end) {
-	requireHandle("removeRange");
 	requireActive("removeRange");
 
 	bump(gOpCounters.clearRanges);
@@ -495,7 +489,6 @@ void Transaction::removeRange(const kv::Key &start, const kv::Key &end) {
 }
 
 void Transaction::addReadConflictKey(const kv::Key &key) {
-	requireHandle("addReadConflictKey");
 	// A read-conflict annotation is a read into the attempt's conflict footprint, so it
 	// obeys the same lifecycle as every other data op: only valid on the live attempt,
 	// never once a failure or commit has moved the transaction on.
@@ -521,7 +514,6 @@ void Transaction::addReadConflictKey(const kv::Key &key) {
 }
 
 bool Transaction::commit() {
-	requireHandle("commit");
 	requireActive("commit");
 
 	// A new attempt invalidates the previous attempt's version: a failed re-commit on a
@@ -536,8 +528,7 @@ bool Transaction::commit() {
 		fdb_error_t injected = FaultInjection::next(faultInjection_->preCommitErrors);
 		if (injected != 0) {
 			error_ = injected;
-			state_ = classifyCommitFailure(injected);
-			lastFailureCode_ = injected;
+			recordFailure(classifyCommitFailure(injected), injected);
 			safs::log_err("Transaction::commit: injected pre-commit error: {}",
 			              fdb_get_error(injected));
 			countFailedCommit(injected);
@@ -562,8 +553,7 @@ bool Transaction::commit() {
 		// The commit was already submitted; a wait-layer failure means its outcome is
 		// UNKNOWN. Force kIndeterminate (never retryable): replaying a commit that actually
 		// landed would double-apply it.
-		state_ = TransactionState::kIndeterminate;
-		lastFailureCode_ = error_;
+		recordFailure(TransactionState::kIndeterminate, error_);
 		safs::log_err("Transaction::commit: fdb_future_block_until_ready: error: {}",
 		              fdb_get_error(error_));
 		countFailedCommit(error_);
@@ -583,8 +573,7 @@ bool Transaction::commit() {
 	}
 
 	if (error_ != 0) {
-		state_ = classifyCommitFailure(error_);
-		lastFailureCode_ = error_;
+		recordFailure(classifyCommitFailure(error_), error_);
 		safs::log_err("Transaction::commit: commit failed: {}", fdb_get_error(error_));
 		countFailedCommit(error_);
 		return false;
@@ -685,8 +674,7 @@ void Transaction::reset() {
 		if (err != 0) {
 			// The handle was reset but the promised option is gone; unusable.
 			error_ = err;
-			state_ = TransactionState::kFailed;
-			lastFailureCode_ = err;
+			recordFailure(TransactionState::kFailed, err);
 			detail::throwTransactionError(err);
 		}
 	}
@@ -695,8 +683,7 @@ void Transaction::reset() {
 		if (err != 0) {
 			// The handle was reset but the promised time bound is gone; unusable.
 			error_ = err;
-			state_ = TransactionState::kFailed;
-			lastFailureCode_ = err;
+			recordFailure(TransactionState::kFailed, err);
 			detail::throwTransactionError(err);
 		}
 	}
@@ -729,8 +716,7 @@ void Transaction::cancel() {
 	fdb_transaction_cancel(tr_.get());
 	constexpr fdb_error_t kTransactionCancelled = 1025;
 	error_ = kTransactionCancelled;
-	state_ = TransactionState::kCancelled;
-	lastFailureCode_ = kTransactionCancelled;
+	recordFailure(TransactionState::kCancelled, kTransactionCancelled);
 }
 
 namespace {
@@ -742,9 +728,15 @@ struct ReadyNode {
 	void *arg;
 };
 
-void fireReadyNode(FDBFuture * /*future*/, void *param) {
+void fireReadyNode(FDBFuture * /*future*/, void *param) noexcept {
 	std::unique_ptr<ReadyNode> node(static_cast<ReadyNode *>(param));
-	if (node->callback != nullptr) { node->callback(node->arg); }
+	if (node->callback == nullptr) { return; }
+	try {
+		node->callback(node->arg);
+	} catch (...) {
+		safs::log_err("fireReadyNode: callback threw across the FDB C callback boundary");
+		std::terminate();
+	}
 }
 
 /// Arms a one-shot ready callback on an FDB future. Routes the wakeup through a
@@ -1072,7 +1064,6 @@ private:
 }  // namespace
 
 std::unique_ptr<kv::ICommitFuture> Transaction::commitAsync() {
-	requireHandle("commitAsync");
 	requireActive("commitAsync");
 
 	// A new attempt invalidates the previous attempt's version: a failed re-commit on a

--- a/src/fdb/fdb.h
+++ b/src/fdb/fdb.h
@@ -20,6 +20,7 @@
 
 #include "common/platform.h"
 
+#include <array>
 #include <cstdint>
 #include <deque>
 #include <memory>
@@ -31,6 +32,7 @@
 #include <foundationdb/fdb_c.h>
 #include <foundationdb/fdb_c_types.h>
 
+#include "kv/ifuture.h"
 #include "kv/itransaction.h"
 
 namespace fdb {
@@ -163,6 +165,9 @@ struct FaultInjection {
 	/// is reported as failed. With commit_unknown_result (1021) this reproduces the
 	/// maybe-committed case, the data IS in the database but the caller cannot know it.
 	std::deque<fdb_error_t> postCommitErrors;
+	/// Commit wait-layer failures: the commit WAS submitted, but fdb_future_block_until_ready
+	/// is scripted to fail, so the outcome is unknown (maybe-committed) regardless of the code.
+	std::deque<fdb_error_t> commitWaitErrors;
 	/// Committed-version lookups after a successful commit.
 	std::deque<fdb_error_t> committedVersionErrors;
 
@@ -179,9 +184,36 @@ struct FaultInjection {
 		readErrors.clear();
 		preCommitErrors.clear();
 		postCommitErrors.clear();
+		commitWaitErrors.clear();
 		committedVersionErrors.clear();
 	}
 };
+
+/// Lifecycle state of a Transaction (one transaction handle, many attempts).
+/// Wrong-state calls throw kv::TransactionStateError (a std::logic_error); destruction is
+/// legal from every state.
+enum class TransactionState {
+	kActive,           ///< Usable: reads, mutations, options, commit, cancel, reset.
+	kCommitInFlight,   ///< commitAsync() issued; only the commit future may act.
+	kRetryPending,     ///< Failed retryable + definitely-not-committed; onErrorAsync/reset/cancel.
+	kBackoffInFlight,  ///< onErrorAsync() issued; only the backoff future may act.
+	kIndeterminate,    ///< Commit outcome unknown (maybe-committed); destroy only.
+	kCommitted,        ///< Commit succeeded; committed-version reads and reset.
+	kFailed,           ///< Non-retryable failure; reset/cancel (destroy only if the
+	                   ///< backoff future was abandoned, see Transaction::reset).
+	kCancelled,        ///< cancel() called; reset only.
+};
+
+/// Human-readable state name for logs and std::logic_error messages.
+const char *transactionStateName(TransactionState state);
+
+namespace detail {
+
+/// Encodes an int-valued FDB option parameter: 8 bytes, little-endian, regardless of
+/// host endianness (the fdb_c option ABI).
+std::array<uint8_t, 8> encodeInt64LE(int64_t value);
+
+}  // namespace detail
 
 /// Custom deleter for FDBFuture (C struct), to ensure proper cleanup.
 struct FDBFutureDeleter {
@@ -196,10 +228,11 @@ using UniqueFDBFuture = std::unique_ptr<FDBFuture, FDBFutureDeleter>;
 
 /// A class that wraps a FoundationDB transaction.
 /// Provides methods to perform read and write operations on the database.
-/// Every read, write, and commit operation throws std::logic_error when the transaction
-/// has no backend handle (moved-from, or constructed from a null or errored database):
-/// per the kv error-domain rules a wrong-state call must never pose as a missing key, an
-/// empty range, or a silently dropped write.
+/// Every operation (reads, writes, options, commit, and the lifecycle calls reset,
+/// cancel, and onErrorAsync) throws std::logic_error when the transaction has no
+/// backend handle (constructed from a null or errored database): per the kv
+/// error-domain rules a wrong-state call must never pose as a missing key, an empty
+/// range, or a silently dropped write.
 class Transaction {
 public:
 	/// Constructs a Transaction object using the provided DB instance.
@@ -217,16 +250,84 @@ public:
 		if (error_ == 0) { tr_.reset(auxTr); }
 	}
 
-	/// Returns the last backend error recorded directly by this wrapper.
-	/// Synchronous point reads and commit outcomes update it. Future-based reads,
-	/// including getRange(), report failures through kv::TransactionError and do not
-	/// update it. A committed-version lookup failure after a durable commit leaves it at 0.
-	fdb_error_t error() const { return error_; }
-	explicit operator bool() const { return error_ == 0 && tr_; }
+	// Non-copyable, non-movable: futures created by this transaction hold raw
+	// pointers to its members (state_, error_, ...), which a move would leave
+	// dangling while the future silently updates the moved-from object.
+	Transaction(const Transaction &) = delete;
+	Transaction &operator=(const Transaction &) = delete;
+	Transaction(Transaction &&) = delete;
+	Transaction &operator=(Transaction &&) = delete;
 
-	/// Sets an option on the transaction.
-	/// @throws std::logic_error when the transaction has no backend handle.
+	~Transaction() = default;
+
+	/// Returns the last backend error recorded directly by this wrapper.
+	/// Synchronous point reads and commit outcomes update it, and so do the lifecycle
+	/// calls: cancel() records 1025 (transaction_cancelled), a failed
+	/// setMaxRetryDelayMs() records the option failure, and reset() or a successful
+	/// onErrorAsync() recovery clears it back to 0. Future-based reads, including
+	/// getRange(), report failures through kv::TransactionError and do not update it.
+	/// A committed-version lookup failure after a durable commit leaves it at 0.
+	fdb_error_t error() const { return error_; }
+
+	/// True when this transaction has a backend handle to operate on. A past
+	/// operation error does NOT make this false: errors surface as exceptions and in
+	/// state()/error(), and reset() can make the handle usable again.
+	explicit operator bool() const { return tr_ != nullptr; }
+
+	/// Current lifecycle state; operations legal per TransactionState. A handle-less
+	/// transaction still reports its state, though every operation on it throws (see
+	/// the class doc).
+	TransactionState state() const { return state_; }
+
+	/// Sets an option on the transaction. Requires kActive.
+	/// @throws std::logic_error when the transaction has no backend handle or is not
+	///   kActive.
 	fdb_error_t setOption(FDBTransactionOption option, std::string_view value = {});
+
+	/// Upper bound in milliseconds for the backoff delay onErrorAsync() may apply
+	/// (FDB max_retry_delay). Sticky: re-applied automatically after reset(), because
+	/// FDB reverts options on reset but keeps them across on_error. Requires kActive.
+	/// @throws std::invalid_argument if ms is outside [0, INT_MAX], the FDB option
+	///   range; kv::TransactionError family if the backend rejects the option.
+	void setMaxRetryDelayMs(int64_t ms);
+
+	/// Total time in milliseconds the transaction may run (reads plus commit) before FDB
+	/// auto-cancels it (FDB TIMEOUT option), surfaced as a transaction_timed_out error.
+	/// Sticky like setMaxRetryDelayMs: re-applied after reset(), and (per FDB) kept across
+	/// on_error, so one call bounds the whole recover-and-replay chain from that point. A
+	/// caller with its own wall-clock retry deadline sets the remaining budget here so a
+	/// stuck backend cannot block past it. Requires kActive.
+	/// @throws std::invalid_argument if ms is outside (0, INT_MAX]: 0 is rejected because FDB
+	///   reads it as "disable the timeout", the opposite of bounding; kv::TransactionError
+	///   family if the backend rejects the option.
+	void setTimeoutMs(int64_t ms);
+
+	/// Begins backend recovery (fdb_transaction_on_error) after a retryable,
+	/// definitely-not-committed failure so this SAME transaction can be replayed with
+	/// FDB's accumulating backoff. Requires kRetryPending; moves to kBackoffInFlight.
+	/// The future's get() returning normally means the transaction is kActive again;
+	/// get() throwing (or abandoning the future unconsumed) leaves it terminal.
+	/// @param err The backend error that put the transaction in kRetryPending.
+	/// @throws std::invalid_argument if err is 0 or is not the failure this
+	///   transaction recorded: the code drives FDB's retry classification and
+	///   backoff, so a code from some other transaction must not be applied here.
+	std::unique_ptr<kv::IVoidFuture> onErrorAsync(fdb_error_t err);
+
+	/// Returns the transaction to kActive for a fresh attempt, discarding buffered
+	/// mutations and clearing the error/committed-version bookkeeping. Sticky options
+	/// (setMaxRetryDelayMs, setTimeoutMs) are re-applied, everything else reverts to defaults.
+	/// Legal from kActive, kRetryPending, kCommitted, kCancelled and error-surfaced
+	/// kFailed. Illegal (std::logic_error) while a commit/backoff future is in flight,
+	/// from kIndeterminate (a maybe-committed op must never be replayed on a reused
+	/// object), and from kFailed entered by abandoning a backoff future (recovery
+	/// outcome unknown; FDB leaves reset-during-on_error undefined).
+	void reset();
+
+	/// Cancels the transaction (outstanding futures resolve with error 1025). Legal
+	/// from kActive, kRetryPending and error-surfaced kFailed; moves to kCancelled.
+	/// Illegal while a commit is in flight (the C API calls the outcome unpredictable;
+	/// abandon the commit future instead, which lands in kIndeterminate).
+	void cancel();
 
 	/// Gets a value for a given key.
 	/// @param key The key to retrieve the value for.
@@ -326,8 +427,9 @@ public:
 	/// Approximate byte size that the buffered mutations and conflict ranges would contribute
 	/// to a commit (fdb_transaction_get_approximate_size). Computed client-side.
 	/// @return The approximate size, or std::nullopt when the size cannot be reported (no
-	///   backend handle, or a backend error). Diagnostic-only, so unlike the data reads
-	///   this deliberately does not throw: nullopt is not confusable with real data.
+	///   backend handle, not kActive, or a backend error). Diagnostic-only, so unlike the
+	///   data reads this deliberately does not throw: nullopt is not confusable with real
+	///   data.
 	std::optional<uint64_t> getApproximateSize() const;
 
 	/// TEST-ONLY: attaches a deterministic fault-injection script to this transaction and
@@ -355,10 +457,44 @@ private:
 		}
 	};
 
+	/// Requires kActive; throws std::logic_error otherwise.
+	void requireActive(const char *operation) const;
+
+	/// Encodes and sets an int-valued transaction option (8-byte little-endian).
+	fdb_error_t setIntOption(FDBTransactionOption option, int64_t value);
+
 	/// The wrapped FDBTransaction pointer.
 	std::unique_ptr<FDBTransaction, FDBTransactionDeleter> tr_;
 	/// The error code of the last operation.
 	fdb_error_t error_{1};
+
+	/// Lifecycle state; transitions per TransactionState. Futures created by this
+	/// transaction hold a pointer to it (like error_/committedVersion_), which is why
+	/// the class is non-movable.
+	TransactionState state_{TransactionState::kActive};
+
+	/// The backend error that accompanied the most recent transition into
+	/// kRetryPending or kFailed (0 when none is pending; reset() clears it, a
+	/// successful recovery clears it). Written by every failure path, including the
+	/// future-based reads that deliberately do not touch the public error_; used to
+	/// validate that onErrorAsync() is driven with this transaction's own failure.
+	fdb_error_t lastFailureCode_{0};
+
+	/// Monotonic attempt counter: bumped every time a new attempt begins on this same
+	/// handle (reset() and a successful onErrorAsync() recovery). Read futures capture it
+	/// at issue time so a future left over from a superseded attempt cannot record its
+	/// failure into the current one (see ReadFailureSink / recordReadFailure).
+	uint64_t attemptGeneration_{0};
+
+	/// Set when kFailed was entered by abandoning a backoff future: the recovery
+	/// outcome is unknown, so reset()/cancel() are forbidden (destroy only).
+	bool backoffAbandoned_{false};
+
+	/// Sticky max_retry_delay value to re-apply after reset() (see setMaxRetryDelayMs).
+	std::optional<int64_t> maxRetryDelayMs_;
+
+	/// Sticky transaction TIMEOUT value to re-apply after reset() (see setTimeoutMs).
+	std::optional<int64_t> timeoutMs_;
 
 	/// The commit version of the transaction, if applicable.
 	std::optional<int64_t> committedVersion_;

--- a/src/fdb/fdb.h
+++ b/src/fdb/fdb.h
@@ -457,8 +457,11 @@ private:
 		}
 	};
 
-	/// Requires kActive; throws std::logic_error otherwise.
+	/// Requires a backend handle in kActive; throws std::logic_error otherwise.
 	void requireActive(const char *operation) const;
+
+	/// Records a backend failure in the coupled lifecycle fields.
+	void recordFailure(TransactionState failureState, fdb_error_t error);
 
 	/// Encodes and sets an int-valued transaction option (8-byte little-endian).
 	fdb_error_t setIntOption(FDBTransactionOption option, int64_t value);

--- a/src/fdb/fdb.h
+++ b/src/fdb/fdb.h
@@ -111,24 +111,6 @@ public:
 	/// @see FDBNetworkOption for available options.
 	static fdb_error_t setNetworkOption(FDBNetworkOption option, std::string_view value = {});
 
-	/// Sets up the FoundationDB network thread.
-	/// This must be called before any database operations.
-	/// @return The error code of the operation.
-	static fdb_error_t setupNetwork();
-
-	/// Runs the FoundationDB network thread.
-	/// This must be called after setting up the network.
-	/// @return The error code of the operation.
-	/// @note This function blocks until the network thread is stopped.
-	/// It is typically called in a separate thread.
-	static fdb_error_t runNetwork();
-
-	/// Stops the FoundationDB network thread.
-	/// This should be called when the application is shutting down.
-	/// @return The error code of the operation.
-	/// @note This function blocks until the network thread is stopped.
-	static fdb_error_t stopNetwork();
-
 	// database
 
 	/// Returns the error code of the last operation.

--- a/src/fdb/fdb_context.cc
+++ b/src/fdb/fdb_context.cc
@@ -16,33 +16,15 @@
    along with SaunaFS  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "common/platform.h"
+
 #include "fdb/fdb_context.h"
 
-#include <stdexcept>
-
+#include "fdb/fdb_errors.h"
+#include "fdb/fdb_runtime.h"
 #include "slogger/slogger.h"
 
 namespace fdb {
-
-class FDBException : public std::runtime_error {
-public:
-	FDBException(int error_code, const std::string &message)
-	    : std::runtime_error("FoundationDB error: " + message +
-	                         " (code: " + std::to_string(error_code) + ")") {}
-};
-
-inline void check_fdb_err(int err, std::string msg) {
-	if (err != 0) {
-		std::string error_str = fmt::format("FoundationDB error: {}. {}", DB::errorMsg(err), msg);
-		safs::log_err(error_str);
-		throw FDBException(err, error_str);
-	}
-}
-
-inline void check_fdb_op(auto &&cmd, std::string msg) {
-	auto err = cmd;
-	check_fdb_err(err, msg);
-}
 
 std::shared_ptr<FDBContext> FDBContext::create(FDBConfig &&config) {
 	return std::shared_ptr<FDBContext>(new FDBContext(std::move(config)));
@@ -50,32 +32,10 @@ std::shared_ptr<FDBContext> FDBContext::create(FDBConfig &&config) {
 
 FDBContext::FDBContext(FDBConfig &&config) : config_(std::move(config)) {
 	try {
-		check_fdb_op(DB::selectAPIVersion(FDB_API_VERSION), "Failed to set API Version");
-		check_fdb_op(DB::setupNetwork(), "Failed to setup network thread");
-
-		networkThread_ = std::thread([] {
-			pthread_setname_np(pthread_self(), "fdb_network");
-			try {
-				DB::runNetwork();
-			} catch (const std::exception &e) {
-				safs::log_err("FoundationDB network thread error: {}", e.what());
-			}
-		});
+		Runtime::ensureStarted();
 	} catch (const FDBException &e) {
 		safs::log_err("Failed to initialize FDBContext: {}", e.what());
 		throw;
-	}
-}
-
-FDBContext::~FDBContext() {
-	if (networkThread_.joinable()) {
-		try {
-			check_fdb_op(DB::stopNetwork(), "Failed to stop network thread");
-			networkThread_.join();
-		} catch (const std::exception &e) {
-			// Log but don't throw from destructor
-			safs::log_err("Error while stopping FDB network thread: {}", e.what());
-		}
 	}
 }
 
@@ -84,7 +44,7 @@ std::shared_ptr<DB> FDBContext::getDB() {
 
 	try {
 		db_ = std::make_shared<DB>(config_.clusterFile);
-		check_fdb_err(db_->error(), "Failed to get fdb::DB instance");
+		checkFdbError(db_->error(), "Failed to get fdb::DB instance");
 		return db_;
 	} catch (const FDBException &e) {
 		safs::log_err("Failed to get DB instance: {}", e.what());

--- a/src/fdb/fdb_context.h
+++ b/src/fdb/fdb_context.h
@@ -18,10 +18,11 @@
 
 #pragma once
 
-#include "fdb/fdb.h"
+#include "common/platform.h"
 
 #include <memory>
-#include <thread>
+
+#include "fdb/fdb.h"
 
 namespace fdb {
 
@@ -32,44 +33,39 @@ struct FDBConfig {
 	std::string clusterFile;
 };
 
-/// FDBContext manages the FoundationDB client library context.
-/// It initializes the network thread and provides access to the database instance.
-/// On destruction, it stops the network thread and cleans up resources.
+/// Handle to one FoundationDB database connection on the shared process-wide runtime
+/// (fdb::Runtime). Creating a context starts the runtime if needed; destroying it never
+/// stops the network (a stopped FDB client cannot be restarted in-process), so contexts
+/// may be created and destroyed freely. The network stops only via an explicit
+/// Runtime::shutdown(); otherwise the runtime is deliberately leaked at process exit (see
+/// fdb::Runtime).
 class FDBContext {
 public:
 	/// Creates a shared pointer to an FDBContext instance.
+	/// @throws FDBException if the shared runtime cannot be started.
+	/// @throws std::logic_error when the runtime was already shut down (it cannot be
+	///   restarted in-process; see fdb::Runtime).
 	static std::shared_ptr<FDBContext> create(FDBConfig &&config);
 
-	/// Not needed constructors and assignment operators.
-	/// Deleted to prevent copying or moving of the FDBContext object.
 	FDBContext(const FDBContext &) = delete;
 	FDBContext &operator=(const FDBContext &) = delete;
 	FDBContext(FDBContext &&) = delete;
 	FDBContext &operator=(FDBContext &&) = delete;
 
-	/// Destructor that stops the network thread and cleans up resources.
-	~FDBContext();
+	~FDBContext() = default;
 
-	/// Returns a shared pointer to the FoundationDB database instance.
-	/// If the database instance is not yet created, it initializes it using the provided
-	/// configuration.
+	/// Returns a shared pointer to the FoundationDB database instance, creating it on
+	/// first use from the configured cluster file.
+	/// @throws FDBException if the database cannot be created.
 	std::shared_ptr<DB> getDB();
 
 private:
-	/// Initializes the FoundationDB client library and starts the network thread.
-	/// @param config Configuration for the FoundationDB client.
 	explicit FDBContext(FDBConfig &&config);
-
-	/// The thread that runs the FoundationDB network loop.
-	/// It is created when the FDBContext is initialized and runs until the context is destroyed.
-	/// This thread is responsible for handling network events and processing transactions.
-	std::thread networkThread_;
 
 	/// The configuration for the FoundationDB client.
 	FDBConfig config_;
 
-	/// The database instance managed by this context.
-	/// It is created lazily when the getDB() method is called.
+	/// The database instance managed by this context, created lazily by getDB().
 	std::shared_ptr<DB> db_;
 };
 

--- a/src/fdb/fdb_errors.h
+++ b/src/fdb/fdb_errors.h
@@ -25,7 +25,37 @@
 
 #include <foundationdb/fdb_c.h>
 
+#include <stdexcept>
+#include <string>
+
 #include "kv/ifuture.h"
+
+namespace fdb {
+
+/// Initialization/lifecycle failure of the FDB client itself (runtime start, database
+/// creation), as opposed to per-transaction errors (kv::TransactionError family).
+class FDBException : public std::runtime_error {
+public:
+	FDBException(int errorCode, const std::string &message)
+	    : std::runtime_error("FoundationDB error: " + message +
+	                         " (code: " + std::to_string(errorCode) + ")"),
+	      errorCode_(errorCode) {}
+
+	/// The fdb_c error code that caused this failure.
+	int errorCode() const noexcept { return errorCode_; }
+
+private:
+	int errorCode_;
+};
+
+/// Throws FDBException when a lifecycle-level fdb_c call failed.
+inline void checkFdbError(fdb_error_t err, const std::string &message) {
+	if (err != 0) {
+		throw FDBException(static_cast<int>(err), message + ": " + std::string(fdb_get_error(err)));
+	}
+}
+
+}  // namespace fdb
 
 namespace fdb::detail {
 

--- a/src/fdb/fdb_errors.h
+++ b/src/fdb/fdb_errors.h
@@ -59,22 +59,27 @@ inline void checkFdbError(fdb_error_t err, const std::string &message) {
 
 namespace fdb::detail {
 
+/// Whether a failed READ may be replayed on a fresh transaction.
+/// transaction_timed_out (1031) is deliberately absent from FDB's RETRYABLE
+/// predicate because a timeout during COMMIT has an unknown result. This predicate
+/// guards READ paths only, and the op-boundary replay runs on a fresh transaction
+/// with a fresh timeout budget, so a timed-out read is safe to replay. The commit
+/// path (FDBCommitFuture::getResult) uses RETRYABLE_NOT_COMMITTED, which excludes
+/// 1031 and the whole maybe-committed class, so a commit with an unknown result is
+/// never blindly replayed.
+inline bool isRetryableReadError(fdb_error_t err) {
+	constexpr fdb_error_t kTransactionTimedOut = 1031;
+	return err == kTransactionTimedOut ||
+	       fdb_error_predicate(FDB_ERROR_PREDICATE_RETRYABLE, err) != 0;
+}
+
 /// Translates a failed FoundationDB READ into the typed error contract: retryable
 /// errors throw kv::RetryableTransactionError so the master's op boundary replays the
 /// op on a fresh transaction, and every other backend error throws the
 /// kv::TransactionError base so a backend failure can never be mistaken for a missing
 /// key (absent keys are the only thing reported as an empty result).
 [[noreturn]] inline void throwTransactionError(fdb_error_t err) {
-	// transaction_timed_out (1031) is deliberately absent from FDB's RETRYABLE
-	// predicate because a timeout during COMMIT has an unknown result. This helper
-	// guards READ paths only, and the op-boundary replay runs on a fresh
-	// transaction with a fresh timeout budget, so a timed-out read is safe to
-	// replay. The commit path (FDBCommitFuture::getResult) uses RETRYABLE_NOT_COMMITTED,
-	// which excludes 1031 and the whole maybe-committed class, so a commit with an
-	// unknown result is never blindly replayed.
-	constexpr fdb_error_t kTransactionTimedOut = 1031;
-	if (err == kTransactionTimedOut ||
-	    fdb_error_predicate(FDB_ERROR_PREDICATE_RETRYABLE, err) != 0) {
+	if (isRetryableReadError(err)) {
 		throw kv::RetryableTransactionError(static_cast<int>(err), fdb_get_error(err));
 	}
 	throw kv::TransactionError(static_cast<int>(err), fdb_get_error(err));

--- a/src/fdb/fdb_future.cc
+++ b/src/fdb/fdb_future.cc
@@ -44,10 +44,29 @@ fdb_error_t injectedReadError(FaultInjection *fault) {
 	return FaultInjection::next(fault->readErrors);
 }
 
+/// Records a failed read in the owning transaction's state (when wired): retryable
+/// errors leave it replayable via onErrorAsync, everything else is terminal. Left inert
+/// unless the transaction is still Active AND still on the attempt that issued this
+/// future. Reads are only issued while Active, so a transaction that already moved on
+/// (commit in flight, committed, maybe-committed, or an earlier recorded failure) is
+/// left untouched: a late-resolving read must never regress a commit outcome. The
+/// generation guard adds the other half: a future from a superseded attempt (after
+/// reset() or a successful recovery re-activated the handle) must not stamp the FRESH
+/// attempt with the old attempt's error, which recovery could then act on.
+void recordReadFailure(const ReadFailureSink &sink, fdb_error_t err) {
+	if (sink.state == nullptr || *sink.state != TransactionState::kActive) { return; }
+	if (sink.attemptGeneration != nullptr && *sink.attemptGeneration != sink.issuedGeneration) {
+		return;
+	}
+	*sink.state = detail::isRetryableReadError(err) ? TransactionState::kRetryPending
+	                                                : TransactionState::kFailed;
+	if (sink.lastFailureCode != nullptr) { *sink.lastFailureCode = err; }
+}
+
 }  // namespace
 
-FDBFutureValue::FDBFutureValue(FDBFuture *future, FaultInjection *fault)
-    : future_(future), faultInjection_(fault) {}
+FDBFutureValue::FDBFutureValue(FDBFuture *future, FaultInjection *fault, ReadFailureSink sink)
+    : future_(future), faultInjection_(fault), sink_(sink) {}
 
 FDBFutureValue::~FDBFutureValue() {
 	if (future_ != nullptr) { fdb_future_destroy(future_); }
@@ -63,8 +82,8 @@ std::optional<kv::Value> FDBFutureValue::get(int *error) {
 	// Wrong-state call per the kv error-domain rules: posing as a missing key would hide
 	// the caller's bug, and no real backend error code exists to report.
 	if (consumed_ || future_ == nullptr) {
-		throw std::logic_error(consumed_ ? "FDBFutureValue::get: future already consumed"
-		                                 : "FDBFutureValue::get: invalid future");
+		throw kv::TransactionStateError(consumed_ ? "FDBFutureValue::get: future already consumed"
+		                                          : "FDBFutureValue::get: invalid future");
 	}
 
 	// Mark as consumed
@@ -74,6 +93,7 @@ std::optional<kv::Value> FDBFutureValue::get(int *error) {
 	// takes exactly the real error path below.
 	if (fdb_error_t injected = injectedReadError(faultInjection_); injected != 0) {
 		if (error != nullptr) { *error = static_cast<int>(injected); }
+		recordReadFailure(sink_, injected);
 		throwTransactionError(injected);
 	}
 
@@ -95,6 +115,7 @@ std::optional<kv::Value> FDBFutureValue::get(int *error) {
 		safs::log_err("FDBFutureValue::get: fdb_future_block_until_ready: error: {}",
 		              fdb_get_error(fdbError));
 		if (error != nullptr) { *error = static_cast<int>(fdbError); }
+		recordReadFailure(sink_, fdbError);
 		throwTransactionError(fdbError);
 	}
 
@@ -109,6 +130,7 @@ std::optional<kv::Value> FDBFutureValue::get(int *error) {
 		safs::log_err("FDBFutureValue::get: fdb_future_get_value: error: {}",
 		              fdb_get_error(fdbError));
 		if (error != nullptr) { *error = static_cast<int>(fdbError); }
+		recordReadFailure(sink_, fdbError);
 		throwTransactionError(fdbError);
 	}
 
@@ -125,8 +147,8 @@ std::optional<kv::Value> FDBFutureValue::get(int *error) {
 	return std::nullopt;
 }
 
-FDBFutureRange::FDBFutureRange(FDBFuture *future, FaultInjection *fault)
-    : future_(future), faultInjection_(fault) {}
+FDBFutureRange::FDBFutureRange(FDBFuture *future, FaultInjection *fault, ReadFailureSink sink)
+    : future_(future), faultInjection_(fault), sink_(sink) {}
 
 FDBFutureRange::~FDBFutureRange() {
 	if (future_ != nullptr) { fdb_future_destroy(future_); }
@@ -142,8 +164,8 @@ kv::GetRangeResult FDBFutureRange::get(int *error) {
 	// Wrong-state call per the kv error-domain rules: posing as an empty range would
 	// hide the caller's bug, and no real backend error code exists to report.
 	if (consumed_ || future_ == nullptr) {
-		throw std::logic_error(consumed_ ? "FDBFutureRange::get: future already consumed"
-		                                 : "FDBFutureRange::get: invalid future");
+		throw kv::TransactionStateError(consumed_ ? "FDBFutureRange::get: future already consumed"
+		                                          : "FDBFutureRange::get: invalid future");
 	}
 
 	consumed_ = true;
@@ -152,6 +174,7 @@ kv::GetRangeResult FDBFutureRange::get(int *error) {
 	// takes exactly the real error path below.
 	if (fdb_error_t injected = injectedReadError(faultInjection_); injected != 0) {
 		if (error != nullptr) { *error = static_cast<int>(injected); }
+		recordReadFailure(sink_, injected);
 		throwTransactionError(injected);
 	}
 
@@ -170,6 +193,7 @@ kv::GetRangeResult FDBFutureRange::get(int *error) {
 		safs::log_err("FDBFutureRange::get: fdb_future_block_until_ready: error: {}",
 		              fdb_get_error(fdbError));
 		if (error != nullptr) { *error = static_cast<int>(fdbError); }
+		recordReadFailure(sink_, fdbError);
 		throwTransactionError(fdbError);
 	}
 
@@ -183,6 +207,7 @@ kv::GetRangeResult FDBFutureRange::get(int *error) {
 		safs::log_err("FDBFutureRange::get: fdb_future_get_keyvalue_array: error: {}",
 		              fdb_get_error(fdbError));
 		if (error != nullptr) { *error = static_cast<int>(fdbError); }
+		recordReadFailure(sink_, fdbError);
 		throwTransactionError(fdbError);
 	}
 

--- a/src/fdb/fdb_future.h
+++ b/src/fdb/fdb_future.h
@@ -20,6 +20,8 @@
 
 #include "common/platform.h"
 
+#include <cstdint>
+
 // Needs to be included before foundationdb/fdb_c.h
 #include <fdb/fdb_api_version.h>
 
@@ -30,6 +32,27 @@
 namespace fdb {
 
 struct FaultInjection;
+enum class TransactionState;
+
+/// Back-reference a read future uses to record a late backend failure into its owning
+/// transaction. recordReadFailure() writes through it only while the transaction is
+/// still on the attempt that issued the future: state Active AND the attempt generation
+/// unchanged. A future from a superseded attempt (after reset() or a successful
+/// onErrorAsync() recovery advanced the generation) is left inert, so it can neither
+/// regress a commit outcome nor stamp the fresh attempt with a stale attempt's error.
+/// All-null (the default) means "not wired": handle-less transactions and detached
+/// futures record nothing.
+struct ReadFailureSink {
+	/// Owning transaction's state; moved to RetryPending/Failed on a wired, in-attempt
+	/// failure, untouched otherwise.
+	TransactionState *state = nullptr;
+	/// Owning transaction's recorded failure code, written together with state.
+	fdb_error_t *lastFailureCode = nullptr;
+	/// Owning transaction's live attempt counter; compared against issuedGeneration.
+	const uint64_t *attemptGeneration = nullptr;
+	/// The attempt (attemptGeneration value) this future was issued in.
+	uint64_t issuedGeneration = 0;
+};
 
 /// Wraps a FoundationDB future (FDBFuture*) with RAII semantics.
 /// Implements the kv::IFuture interface for asynchronous get operations.
@@ -41,7 +64,12 @@ public:
 	/// Constructs a FDBFutureValue wrapping the given FDBFuture*.
 	/// @param future The FDB future to wrap. Takes ownership.
 	/// @param fault Optional TEST-ONLY fault-injection script (not owned, may be null).
-	explicit FDBFutureValue(FDBFuture *future, FaultInjection *fault = nullptr);
+	/// @param sink Back-reference for recording a late read failure into the owning
+	///   transaction, guarded to the issuing attempt (see ReadFailureSink); default is
+	///   inert, so a late-resolving read never regresses a commit outcome or a fresh
+	///   attempt.
+	explicit FDBFutureValue(FDBFuture *future, FaultInjection *fault = nullptr,
+	                        ReadFailureSink sink = {});
 
 	/// Destructor. Destroys the wrapped FDB future.
 	~FDBFutureValue() override;
@@ -72,6 +100,9 @@ private:
 	bool consumed_ = false;
 	/// TEST-ONLY fault-injection script; null in production.
 	FaultInjection *faultInjection_;
+	/// Records a late read failure into the owning transaction, guarded so a superseded
+	/// attempt's future stays inert (see ReadFailureSink).
+	ReadFailureSink sink_;
 };
 
 /// Wraps a FoundationDB range future (FDBFuture*) with RAII semantics.
@@ -84,7 +115,12 @@ public:
 	/// Constructs a FDBFutureRange wrapping the given FDBFuture*.
 	/// @param future The FDB future to wrap. Takes ownership.
 	/// @param fault Optional TEST-ONLY fault-injection script (not owned, may be null).
-	explicit FDBFutureRange(FDBFuture *future, FaultInjection *fault = nullptr);
+	/// @param sink Back-reference for recording a late read failure into the owning
+	///   transaction, guarded to the issuing attempt (see ReadFailureSink); default is
+	///   inert, so a late-resolving read never regresses a commit outcome or a fresh
+	///   attempt.
+	explicit FDBFutureRange(FDBFuture *future, FaultInjection *fault = nullptr,
+	                        ReadFailureSink sink = {});
 
 	/// Destructor. Destroys the wrapped FDB future.
 	~FDBFutureRange() override;
@@ -115,6 +151,9 @@ private:
 	bool consumed_ = false;
 	/// TEST-ONLY fault-injection script; null in production.
 	FaultInjection *faultInjection_;
+	/// Records a late read failure into the owning transaction, guarded so a superseded
+	/// attempt's future stays inert (see ReadFailureSink).
+	ReadFailureSink sink_;
 };
 
 }  // namespace fdb

--- a/src/fdb/fdb_kv_engine.h
+++ b/src/fdb/fdb_kv_engine.h
@@ -51,14 +51,14 @@ public:
 	/// Creates a new transaction for reading and writing.
 	/// @return A pointer to the created transaction.
 	std::unique_ptr<kv::IReadWriteTransaction> createReadWriteTransaction() override {
-		fdb::Transaction auxTr(db_.get());
+		auto transaction = std::make_unique<fdb::FDBTransaction>(db_.get());
 
-		if (!auxTr) {
+		if (!*transaction) {
 			safs::log_err("FDBKVEngine::createReadWriteTransaction: Failed to create transaction");
 			return nullptr;
 		}
 
-		return std::make_unique<fdb::FDBTransaction>(std::move(auxTr));
+		return transaction;
 	}
 
 private:

--- a/src/fdb/fdb_runtime.cc
+++ b/src/fdb/fdb_runtime.cc
@@ -1,0 +1,223 @@
+/*
+   Copyright 2026      Leil Storage OÜ
+
+   This file is part of SaunaFS.
+
+   SaunaFS is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, version 3.
+
+   SaunaFS is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with SaunaFS. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "common/platform.h"
+
+#include <chrono>
+#include <condition_variable>
+#include <cstdlib>
+#include <mutex>
+#include <stdexcept>
+
+// Needs to be included before foundationdb/fdb_c.h
+#include <fdb/fdb_api_version.h>
+
+#include <foundationdb/fdb_c.h>
+
+#include "fdb/fdb_errors.h"
+#include "fdb/fdb_runtime.h"
+#include "slogger/slogger.h"
+
+namespace fdb {
+
+namespace detail {
+
+RuntimeApi defaultRuntimeApi() {
+	return {
+	    [](int version) { return fdb_select_api_version(version); },
+	    []() { return fdb_setup_network(); },
+	    []() { return fdb_run_network(); },
+	    []() { return fdb_stop_network(); },
+	};
+}
+
+RuntimeCore::~RuntimeCore() { shutdown(); }
+
+void RuntimeCore::ensureStarted(int apiVersion) {
+	std::lock_guard<std::mutex> guard(mutex_);
+	if (state_ == State::kRunning) {
+		// A healthy run_network never returns; if it has, the event loop is gone (rejected
+		// at startup, failed later, or stopped out-of-band) and cannot be relaunched, so
+		// pretending the runtime is healthy would hand out futures that never resolve.
+		bool networkReturned = false;
+		fdb_error_t networkError = 0;
+		{
+			std::lock_guard<std::mutex> startupLock(netState_->startupMutex);
+			networkReturned = netState_->runNetworkReturned;
+			networkError = netState_->error.load();
+		}
+		if (networkReturned) {
+			throw FDBException(static_cast<int>(networkError),
+			                   "FDB network is not running; the client cannot make progress");
+		}
+		return;
+	}
+	if (state_ == State::kStopped) {
+		// fdb_stop_network is final for the process; a restart would hang or crash
+		// inside the client library, so fail loudly instead. This is a wrong-state
+		// call by the caller, not an fdb_c failure, hence std::logic_error and not
+		// FDBException (see the error-domain rules in kv/ifuture.h).
+		throw std::logic_error("FDB runtime cannot be restarted after shutdown");
+	}
+
+	// 2201 (api_version_already_set) is fine: a previous start attempt may have
+	// selected the version before failing at a later step.
+	constexpr fdb_error_t kApiVersionAlreadySet = 2201;
+	fdb_error_t selectError = api_.selectApiVersion(apiVersion);
+	if (selectError != kApiVersionAlreadySet) {
+		checkFdbError(selectError, "Failed to select FDB API version");
+	}
+	// Same for 2009 (network_already_setup): a previous attempt may have set up the
+	// network and then failed to launch the network thread, leaving state_ at
+	// kNotStarted with the setup already done.
+	constexpr fdb_error_t kNetworkAlreadySetup = 2009;
+	fdb_error_t setupError = api_.setupNetwork();
+	if (setupError != kNetworkAlreadySetup) {
+		checkFdbError(setupError, "Failed to set up FDB network");
+	}
+
+	// The shared_ptr copy keeps the shared state alive if the thread outlives this object
+	// (the detach path in shutdown()); the lambda must not capture `this`.
+	networkThread_ = std::thread([api = api_, netState = netState_] {
+		pthread_setname_np(pthread_self(), "fdb_network");
+		{
+			std::lock_guard<std::mutex> startupLock(netState->startupMutex);
+			netState->enteredRunNetwork = true;
+		}
+		netState->startupCv.notify_all();
+		fdb_error_t err = api.runNetwork();
+		// run_network returns only on failure or, after a healthy run, once the network is
+		// stopped. Sample startupCommitted and shutdownRequested under the same lock
+		// ensureStarted()/shutdown() set them under, so the fail-stop decision is race-free.
+		bool committed = false;
+		bool shutdownRequested = false;
+		{
+			std::lock_guard<std::mutex> startupLock(netState->startupMutex);
+			if (err != 0) { netState->error.store(err); }
+			netState->runNetworkReturned = true;
+			committed = netState->startupCommitted;
+			shutdownRequested = netState->shutdownRequested;
+		}
+		netState->startupCv.notify_all();
+		if (err != 0) {
+			safs::log_err("FDB network thread exited with error: {}", fdb_get_error(err));
+		}
+		// Any return after startup that shutdown() did not request is fatal, INCLUDING a
+		// clean one: run_network only returns 0 once the network is stopped, so a clean
+		// return we did not ask for means it was stopped out-of-band. The event loop is gone
+		// either way, so fail-stop (supervisor restarts) rather than let later FDB calls run
+		// after stop or hang every future. A startup-time failure is not committed and is
+		// surfaced to the first ensureStarted() instead.
+		if (committed && !shutdownRequested) {
+			safs::log_err("FDB network event loop exited unexpectedly, aborting process");
+			std::abort();
+		}
+	});
+
+	// fdb_run_network rejects synchronously at entry (bad init, already run), so an
+	// immediate failure surfaces within a short grace window. A healthy run_network
+	// blocks and never resolves the handshake, so the wait simply times out and we
+	// proceed. Without this a single-client process (the master creates exactly one
+	// FDBContext) would miss the failure entirely and hang on its first future, because
+	// no later ensureStarted() runs to observe netState_->error. The wait is only paid
+	// on the success path and only once per process.
+	constexpr auto kStartupFailureGrace = std::chrono::milliseconds(100);
+	fdb_error_t startupError = 0;
+	bool networkReturned = false;
+	{
+		std::unique_lock<std::mutex> startupLock(netState_->startupMutex);
+		// Wait for the thread to actually enter run_network first, so the grace bounds only
+		// the synchronous entry-to-rejection window, not thread-scheduling latency (which
+		// could otherwise let a real rejection go unobserved on a loaded box).
+		netState_->startupCv.wait(startupLock, [this] { return netState_->enteredRunNetwork; });
+		netState_->startupCv.wait_for(startupLock, kStartupFailureGrace,
+		                              [this] { return netState_->runNetworkReturned; });
+		startupError = netState_->error.load();
+		networkReturned = netState_->runNetworkReturned;
+		// Commit only if the loop is still running. A healthy run_network never returns, so
+		// ANY return during startup (a synchronous rejection, or an out-of-band stop even a
+		// clean one) means a dead network the thread cannot relaunch.
+		if (!networkReturned) { netState_->startupCommitted = true; }
+	}
+	// Match the kRunning branch: the network was set up and the thread launched, so the
+	// runtime is kRunning even when doomed; a doomed one then refuses every start.
+	state_ = State::kRunning;
+	if (networkReturned) {
+		throw FDBException(
+		    static_cast<int>(startupError),
+		    "FDB network stopped or failed at startup; the client cannot make progress");
+	}
+}
+
+void RuntimeCore::shutdown() {
+	std::lock_guard<std::mutex> guard(mutex_);
+	if (state_ != State::kRunning) {
+		state_ = State::kStopped;
+		return;
+	}
+	state_ = State::kStopped;
+
+	// Mark the stop as coordinated before requesting it, so the network thread's imminent
+	// run_network return is expected and does not trip the post-startup fail-stop.
+	{
+		std::lock_guard<std::mutex> startupLock(netState_->startupMutex);
+		netState_->shutdownRequested = true;
+	}
+
+	fdb_error_t err = api_.stopNetwork();
+	if (err != 0) {
+		// The network refused to stop, so the thread will never exit: joining would
+		// hang shutdown forever. Detach and leak the thread; the process is exiting
+		// this runtime anyway.
+		safs::log_err("FDB stop_network failed, detaching network thread: {}", fdb_get_error(err));
+		if (networkThread_.joinable()) { networkThread_.detach(); }
+		return;
+	}
+	if (networkThread_.joinable()) { networkThread_.join(); }
+}
+
+RuntimeCore::State RuntimeCore::state() const {
+	std::lock_guard<std::mutex> guard(mutex_);
+	return state_;
+}
+
+}  // namespace detail
+
+namespace {
+
+detail::RuntimeCore &globalCore() {
+	// Deliberately leaked (never deleted): a function-local static would register a
+	// destructor that stops the network at process exit, but fdb_stop_network must be
+	// the LAST fdb_c call, after every DB and future is destroyed. Static-destructor
+	// order cannot guarantee that against DB objects owned elsewhere (e.g. the master's
+	// filesystem operations), so an at-exit stop could call into the client after
+	// teardown. Leaking leaves the network thread for the OS to reclaim; an explicit
+	// Runtime::shutdown() still stops it cleanly in a known-safe order.
+	static detail::RuntimeCore *core = new detail::RuntimeCore();
+	return *core;
+}
+
+}  // namespace
+
+void Runtime::ensureStarted() { globalCore().ensureStarted(FDB_API_VERSION); }
+
+void Runtime::shutdown() { globalCore().shutdown(); }
+
+detail::RuntimeCore::State Runtime::state() { return globalCore().state(); }
+
+}  // namespace fdb

--- a/src/fdb/fdb_runtime.h
+++ b/src/fdb/fdb_runtime.h
@@ -1,0 +1,161 @@
+/*
+   Copyright 2026      Leil Storage OÜ
+
+   This file is part of SaunaFS.
+
+   SaunaFS is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, version 3.
+
+   SaunaFS is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with SaunaFS. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "common/platform.h"
+
+#include <atomic>
+#include <condition_variable>
+#include <memory>
+#include <mutex>
+#include <thread>
+
+#include <foundationdb/fdb_c_types.h>
+
+namespace fdb {
+
+namespace detail {
+
+/// Indirection over the process-wide fdb_c calls so RuntimeCore is testable without a
+/// real client library initialization (which is once-per-process and irreversible).
+/// Production uses defaultRuntimeApi(); tests substitute failing/counting stubs.
+struct RuntimeApi {
+	fdb_error_t (*selectApiVersion)(int version);
+	fdb_error_t (*setupNetwork)();
+	fdb_error_t (*runNetwork)();
+	fdb_error_t (*stopNetwork)();
+};
+
+/// The real fdb_c entry points.
+RuntimeApi defaultRuntimeApi();
+
+/// State shared with the network thread. The thread can outlive its RuntimeCore on the
+/// detach path in shutdown() (a refused fdb_stop_network never lets it exit), so this
+/// lives on the heap behind a shared_ptr and the thread lambda captures that copy, never
+/// `this`. Carries the thread's exit error plus the startup handshake the first
+/// ensureStarted() blocks on to catch an immediate fdb_run_network failure.
+struct NetworkThreadState {
+	/// Nonzero once fdb_run_network returned an error and the client can no longer make
+	/// progress. ensureStarted() reads it to refuse a doomed runtime instead of handing
+	/// out futures that never resolve.
+	std::atomic<fdb_error_t> error{0};
+	std::mutex startupMutex;
+	std::condition_variable startupCv;
+	/// Set by the network thread immediately before it calls run_network. ensureStarted()
+	/// waits on this first, so the startup grace bounds only the synchronous entry-to-
+	/// rejection window and not thread-scheduling latency under load (which could otherwise
+	/// let a real rejection go unobserved and a doomed runtime pass as healthy). Guarded by
+	/// startupMutex.
+	bool enteredRunNetwork = false;
+	/// Set once fdb_run_network has returned. During startup that only happens when it
+	/// rejected (a healthy run_network blocks until fdb_stop_network), so it is the
+	/// signal the first ensureStarted() waits on. Guarded by startupMutex.
+	bool runNetworkReturned = false;
+	/// Set by ensureStarted() once startup committed without error. After that, a
+	/// fdb_run_network return is an unexpected post-startup death that no later
+	/// ensureStarted() observes (a single-client process makes none), so the network thread
+	/// fail-stops rather than hang every future. Read under startupMutex, race-free against
+	/// ensureStarted() deciding to commit.
+	bool startupCommitted = false;
+	/// Set by shutdown() before it stops the network, so the thread can tell a coordinated
+	/// stop (run_network returns as asked) from an out-of-band one (stopped behind our back,
+	/// which fail-stops even on a clean return). Guarded by startupMutex.
+	bool shutdownRequested = false;
+};
+
+/// Lifecycle of the process-wide FoundationDB client: API-version selection, network
+/// setup, the network thread, and shutdown. The underlying client is once-per-process
+/// and cannot be restarted after fdb_stop_network, which is why the state machine is
+/// one-way: NotStarted -> Running -> Stopped, and start() from Stopped fails.
+///
+/// This class holds the logic and is instantiable so tests can drive every path with
+/// stubbed RuntimeApi hooks; production goes through the fdb::Runtime singleton facade.
+class RuntimeCore {
+public:
+	enum class State {
+		kNotStarted,
+		kRunning,
+		kStopped
+	};
+
+	explicit RuntimeCore(RuntimeApi api = defaultRuntimeApi()) : api_(api) {}
+
+	RuntimeCore(const RuntimeCore &) = delete;
+	RuntimeCore &operator=(const RuntimeCore &) = delete;
+	RuntimeCore(RuntimeCore &&) = delete;
+	RuntimeCore &operator=(RuntimeCore &&) = delete;
+
+	/// Joins the network thread if still running (see shutdown()).
+	~RuntimeCore();
+
+	/// Selects the API version, configures the network, and starts the network thread.
+	/// Thread-safe and idempotent while Running. The first start briefly waits for the
+	/// network thread so an fdb_run_network that rejects at startup is surfaced here
+	/// rather than only on a later call (which a single-client process never makes).
+	/// @throws FDBException if initialization fails, if the network thread rejected at
+	///   startup, or when it has already exited with an error: the event loop is gone,
+	///   every future would hang, and fdb_run_network cannot be called again in-process.
+	/// @throws std::logic_error when called after shutdown(): a wrong-state call, since
+	///   the client cannot be restarted in-process.
+	void ensureStarted(int apiVersion);
+
+	/// Stops the network and joins its thread. Thread-safe and idempotent; safe to call
+	/// without a prior ensureStarted(). After this the FDB client is unusable for the
+	/// rest of the process lifetime.
+	void shutdown();
+
+	State state() const;
+
+private:
+	RuntimeApi api_;
+	mutable std::mutex mutex_;
+	State state_ = State::kNotStarted;
+	std::thread networkThread_;
+	/// Shared with the network thread (which may outlive this object on the detach path
+	/// in shutdown()): the thread's exit error and the startup handshake. See
+	/// NetworkThreadState.
+	std::shared_ptr<NetworkThreadState> netState_ = std::make_shared<NetworkThreadState>();
+};
+
+}  // namespace detail
+
+/// Process-wide FoundationDB client runtime (singleton facade over RuntimeCore).
+///
+/// Every FDBContext shares this runtime: contexts are cheap handles, and destroying
+/// them never stops the network (a stopped client cannot be restarted, so refcounted
+/// stop-on-last-owner would break any later create). The singleton is deliberately
+/// leaked at process exit: fdb_stop_network must be the last fdb_c call, after every DB
+/// and future is destroyed, and static-destructor order cannot guarantee that against
+/// DB objects owned elsewhere. Leaking leaves the network thread for the OS to reclaim;
+/// an explicit shutdown() (tests, controlled teardown) still stops it in a safe order.
+class Runtime {
+public:
+	/// Starts the shared runtime with the compiled FDB_API_VERSION if not yet running.
+	/// @throws FDBException on failure.
+	/// @throws std::logic_error when the runtime was already shut down (it cannot be
+	///   restarted in-process).
+	static void ensureStarted();
+
+	/// Stops the shared runtime. Idempotent.
+	static void shutdown();
+
+	static detail::RuntimeCore::State state();
+};
+
+}  // namespace fdb

--- a/src/fdb/fdb_runtime_unittest.cc
+++ b/src/fdb/fdb_runtime_unittest.cc
@@ -1,0 +1,263 @@
+/*
+   Copyright 2026      Leil Storage OÜ
+
+   This file is part of SaunaFS.
+
+   SaunaFS is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, version 3.
+
+   SaunaFS is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with SaunaFS. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "common/platform.h"
+
+#include <atomic>
+#include <chrono>
+#include <stdexcept>
+#include <thread>
+
+#include <gtest/gtest.h>
+
+#include "fdb/fdb_errors.h"
+#include "fdb/fdb_runtime.h"
+
+using fdb::detail::RuntimeApi;
+using fdb::detail::RuntimeCore;
+using State = fdb::detail::RuntimeCore::State;
+
+namespace {
+
+constexpr int kApiVersion = 730;
+constexpr fdb_error_t kClientInvalidOperation = 2000;
+constexpr fdb_error_t kNetworkAlreadySetup = 2009;
+constexpr fdb_error_t kApiVersionAlreadySet = 2201;
+
+// Hermetic stubs for the process-wide fdb_c calls (RuntimeApi holds plain function
+// pointers, so state lives at file scope and is reset per test).
+struct StubState {
+	std::atomic<int> selectCalls{0};
+	std::atomic<int> setupCalls{0};
+	std::atomic<int> runCalls{0};
+	std::atomic<int> stopCalls{0};
+	std::atomic<fdb_error_t> selectResult{0};
+	std::atomic<fdb_error_t> setupResult{0};
+	std::atomic<fdb_error_t> runResult{0};
+	std::atomic<fdb_error_t> stopResult{0};
+	std::atomic<bool> blockRun{false};
+	std::atomic<bool> runReleased{false};
+	std::atomic<bool> networkStopped{false};
+
+	void reset() {
+		selectCalls = 0;
+		setupCalls = 0;
+		runCalls = 0;
+		stopCalls = 0;
+		selectResult = 0;
+		setupResult = 0;
+		runResult = 0;
+		stopResult = 0;
+		blockRun = false;
+		runReleased = false;
+		networkStopped = false;
+	}
+};
+
+StubState gStub;
+
+RuntimeApi stubApi() {
+	return {
+	    [](int /*version*/) {
+		    gStub.selectCalls++;
+		    return gStub.selectResult.load();
+	    },
+	    []() {
+		    gStub.setupCalls++;
+		    return gStub.setupResult.load();
+	    },
+	    []() -> fdb_error_t {
+		    gStub.runCalls++;
+		    // A synchronous rejection returns at once; a healthy loop blocks until the
+		    // network is stopped, like the real fdb_run_network (blockRun forces blocking
+		    // even for a scripted nonzero result, for the post-startup-death tests).
+		    if (gStub.runResult != 0 && !gStub.blockRun) { return gStub.runResult.load(); }
+		    while (!gStub.networkStopped && !gStub.runReleased) {
+			    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+		    }
+		    return gStub.runResult.load();
+	    },
+	    []() {
+		    gStub.stopCalls++;
+		    const fdb_error_t result = gStub.stopResult.load();
+		    if (result == 0) { gStub.networkStopped = true; }  // a successful stop ends run_network
+		    return result;
+	    },
+	};
+}
+
+class FDBRuntimeCoreTest : public ::testing::Test {
+protected:
+	void SetUp() override { gStub.reset(); }
+};
+
+}  // namespace
+
+TEST_F(FDBRuntimeCoreTest, StartIsIdempotentAndShutdownStopsOnce) {
+	RuntimeCore core(stubApi());
+	EXPECT_EQ(core.state(), State::kNotStarted);
+
+	core.ensureStarted(kApiVersion);
+	core.ensureStarted(kApiVersion);
+	EXPECT_EQ(core.state(), State::kRunning);
+	EXPECT_EQ(gStub.selectCalls, 1);
+	EXPECT_EQ(gStub.setupCalls, 1);
+
+	core.shutdown();
+	core.shutdown();
+	EXPECT_EQ(core.state(), State::kStopped);
+	EXPECT_EQ(gStub.stopCalls, 1);
+	EXPECT_EQ(gStub.runCalls, 1);
+}
+
+TEST_F(FDBRuntimeCoreTest, SetupFailureThrowsAndAllowsRetry) {
+	RuntimeCore core(stubApi());
+	gStub.setupResult = kClientInvalidOperation;  // arbitrary failure code
+
+	EXPECT_THROW(core.ensureStarted(kApiVersion), fdb::FDBException);
+	EXPECT_EQ(core.state(), State::kNotStarted);
+
+	gStub.setupResult = 0;
+	// The retry re-selects the API version; 2201 (already set) must not fail it.
+	gStub.selectResult = kApiVersionAlreadySet;
+	core.ensureStarted(kApiVersion);
+	EXPECT_EQ(core.state(), State::kRunning);
+	core.shutdown();
+}
+
+TEST_F(FDBRuntimeCoreTest, NetworkAlreadySetupIsTolerated) {
+	RuntimeCore core(stubApi());
+	// Simulates a retry after a first attempt that set up the network but failed to
+	// launch the network thread: setup reports 2009 (network_already_setup), which
+	// must not fail the retry.
+	gStub.selectResult = kApiVersionAlreadySet;
+	gStub.setupResult = kNetworkAlreadySetup;
+	core.ensureStarted(kApiVersion);
+	EXPECT_EQ(core.state(), State::kRunning);
+	core.shutdown();
+}
+
+TEST_F(FDBRuntimeCoreTest, ImmediateNetworkFailureFailsFirstStart) {
+	RuntimeCore core(stubApi());
+	// run_network rejects at once (blockRun stays false): the startup handshake must let
+	// the FIRST start observe it instead of reporting a healthy runtime. This is the
+	// single-client case (the master creates exactly one FDBContext), where no later
+	// ensureStarted() would run to surface the failure.
+	gStub.runResult = kClientInvalidOperation;
+
+	try {
+		core.ensureStarted(kApiVersion);
+		FAIL() << "The first start must surface an immediate run_network failure.";
+	} catch (const fdb::FDBException &e) { EXPECT_EQ(e.errorCode(), kClientInvalidOperation); }
+
+	// kRunning (network set up, thread launched) but doomed, so every start refuses.
+	EXPECT_EQ(core.state(), State::kRunning);
+	EXPECT_THROW(core.ensureStarted(kApiVersion), fdb::FDBException);
+
+	core.shutdown();
+	EXPECT_EQ(core.state(), State::kStopped);
+}
+
+TEST_F(FDBRuntimeCoreTest, ImmediateCleanNetworkExitFailsFirstStart) {
+	RuntimeCore core(stubApi());
+	// The network is stopped out-of-band so run_network returns SUCCESS inside the startup
+	// window. A healthy loop never returns, so this clean return must fail the first start
+	// (not pass as healthy) and every later start must keep refusing it.
+	gStub.networkStopped = true;
+	gStub.runResult = 0;
+
+	EXPECT_THROW(core.ensureStarted(kApiVersion), fdb::FDBException);
+	EXPECT_EQ(core.state(), State::kRunning);
+	EXPECT_THROW(core.ensureStarted(kApiVersion), fdb::FDBException);
+
+	core.shutdown();
+	EXPECT_EQ(core.state(), State::kStopped);
+}
+
+TEST_F(FDBRuntimeCoreTest, PostStartupNetworkDeathAbortsProcess) {
+	// A run_network return AFTER startup committed is an unobservable post-startup death:
+	// the single-client master would hang every future forever, so the network thread
+	// fail-stops. run_network blocks past the grace (startup commits healthy), then is
+	// released to return an error. The empty matcher asserts the process dies without
+	// depending on the test logger reaching stderr.
+	EXPECT_DEATH(
+	    {
+		    gStub.reset();
+		    gStub.blockRun = true;
+		    gStub.runResult = kClientInvalidOperation;
+		    RuntimeCore core(stubApi());
+		    core.ensureStarted(kApiVersion);
+		    gStub.runReleased = true;
+		    std::this_thread::sleep_for(std::chrono::seconds(5));
+	    },
+	    "");
+}
+
+TEST_F(FDBRuntimeCoreTest, PostStartupCleanNetworkExitAbortsProcess) {
+	// Zero-exit twin of the above: run_network returns SUCCESS after startup because the
+	// network was stopped out-of-band (not via shutdown()). The event loop is gone all the
+	// same, so an unrequested clean return must fail-stop, not silently report a healthy
+	// runtime that later FDB calls would use after stop.
+	EXPECT_DEATH(
+	    {
+		    gStub.reset();
+		    gStub.blockRun = true;
+		    gStub.runResult = 0;  // clean return once released, with no shutdown() requested
+		    RuntimeCore core(stubApi());
+		    core.ensureStarted(kApiVersion);
+		    gStub.runReleased = true;
+		    std::this_thread::sleep_for(std::chrono::seconds(5));
+	    },
+	    "");
+}
+
+TEST_F(FDBRuntimeCoreTest, RestartAfterShutdownThrows) {
+	RuntimeCore core(stubApi());
+	core.ensureStarted(kApiVersion);
+	core.shutdown();
+
+	EXPECT_THROW(core.ensureStarted(kApiVersion), std::logic_error);
+	EXPECT_EQ(core.state(), State::kStopped);
+	EXPECT_EQ(gStub.setupCalls, 1);
+}
+
+TEST_F(FDBRuntimeCoreTest, ShutdownWithoutStartIsTerminal) {
+	RuntimeCore core(stubApi());
+	core.shutdown();
+	EXPECT_EQ(core.state(), State::kStopped);
+	EXPECT_EQ(gStub.stopCalls, 0) << "Nothing was running, nothing to stop.";
+	EXPECT_THROW(core.ensureStarted(kApiVersion), std::logic_error);
+}
+
+TEST_F(FDBRuntimeCoreTest, StopFailureDetachesInsteadOfHanging) {
+	gStub.blockRun = true;
+	gStub.stopResult = 1;  // stop_network failure: the network thread never exits
+
+	auto core = std::make_unique<RuntimeCore>(stubApi());
+	core->ensureStarted(kApiVersion);
+
+	// Must return promptly (detach) although the network thread is still blocked; a
+	// join here would hang forever.
+	core->shutdown();
+	EXPECT_EQ(core->state(), State::kStopped);
+	core.reset();
+
+	// Unblock and give the detached thread time to exit before the test ends.
+	gStub.runReleased = true;
+	std::this_thread::sleep_for(std::chrono::milliseconds(20));
+}

--- a/src/fdb/fdb_transaction.cc
+++ b/src/fdb/fdb_transaction.cc
@@ -97,4 +97,38 @@ std::optional<uint64_t> FDBTransaction::getApproximateSize() const {
 	return tr_.getApproximateSize();
 }
 
+namespace {
+
+/// Adapter shim over the wrapper's backoff future: a successful recovery must also
+/// reset the ADAPTER's bookkeeping (mutationCount lives here, not in the wrapper).
+class RecoveryFuture final : public kv::IVoidFuture {
+public:
+	RecoveryFuture(std::unique_ptr<kv::IVoidFuture> inner, uint64_t *mutationCount)
+	    : inner_(std::move(inner)), mutationCount_(mutationCount) {}
+
+	bool isReady() override { return inner_->isReady(); }
+
+	void setReadyCallback(void (*callback)(void *), void *arg) override {
+		inner_->setReadyCallback(callback, arg);
+	}
+
+	void get() override {
+		inner_->get();
+		*mutationCount_ = 0;
+	}
+
+private:
+	std::unique_ptr<kv::IVoidFuture> inner_;
+	uint64_t *mutationCount_;
+};
+
+}  // namespace
+
+std::unique_ptr<kv::IVoidFuture> FDBTransaction::recoverAsync(int backendErrorCode) {
+	auto inner = tr_.onErrorAsync(static_cast<fdb_error_t>(backendErrorCode));
+	return std::make_unique<RecoveryFuture>(std::move(inner), &mutationCount_);
+}
+
+void FDBTransaction::setTimeoutMs(int ms) { tr_.setTimeoutMs(ms); }
+
 }  // namespace fdb

--- a/src/fdb/fdb_transaction.h
+++ b/src/fdb/fdb_transaction.h
@@ -143,6 +143,15 @@ public:
 	/// Returns the committed version of the transaction, if available.
 	std::optional<int64_t> getCommittedVersion() const override;
 
+	/// Begins FDB-managed recovery (fdb_transaction_on_error) so this SAME transaction
+	/// can be replayed with the backend's accumulating backoff. Resets mutationCount().
+	/// @see kv::IReadWriteTransaction::recoverAsync for the full contract.
+	std::unique_ptr<kv::IVoidFuture> recoverAsync(int backendErrorCode) override;
+
+	/// Bounds the transaction's total blocking time (FDB TIMEOUT option); sticky across
+	/// recoverAsync() retries. @see kv::IReadWriteTransaction::setTimeoutMs.
+	void setTimeoutMs(int ms) override;
+
 	/// Number of buffered mutations issued on this transaction so far.
 	uint64_t mutationCount() const override { return mutationCount_; }
 

--- a/src/fdb/fdb_transaction.h
+++ b/src/fdb/fdb_transaction.h
@@ -35,9 +35,15 @@ namespace fdb {
 /// it returns std::nullopt when no estimate can be reported.
 class FDBTransaction final : public kv::IReadWriteTransaction {
 public:
-	/// Constructs a FDBTransaction using the provided fdb::Transaction.
-	/// @param _tr The fdb::Transaction to wrap.
-	FDBTransaction(fdb::Transaction &&_tr) : tr_(std::move(_tr)) {}
+	/// Constructs a FDBTransaction wrapping a new fdb::Transaction on the given
+	/// database (constructed in place: fdb::Transaction is non-movable because its
+	/// futures hold pointers into it).
+	/// @param db The database to create the wrapped transaction on; may be null,
+	///   which yields a handle-less transaction (see operator bool).
+	explicit FDBTransaction(fdb::DB *db) : tr_(db) {}
+
+	/// True when the wrapped transaction has a backend handle to operate on.
+	explicit operator bool() const { return static_cast<bool>(tr_); }
 
 	// Non-copyable, non-movable (base class is non-movable)
 	FDBTransaction(const FDBTransaction &) = delete;

--- a/src/fdb/fdb_unittest.cc
+++ b/src/fdb/fdb_unittest.cc
@@ -35,6 +35,7 @@
 #include "fdb/fdb.h"
 #include "fdb/fdb_context.h"
 #include "fdb/fdb_kv_engine.h"
+#include "fdb/fdb_transaction.h"
 #include "kv/ifuture.h"
 #include "kv/itransaction.h"
 #include "kv/kv_utils.h"
@@ -1091,6 +1092,61 @@ TEST_F(FDBKVEngineTest, MutationCount) {
 
 	txn->removeRange(kv::toBytes("mc_a"), kv::toBytes("mc_b"));
 	EXPECT_EQ(txn->mutationCount(), uint64_t{5}) << "removeRange() buffers one mutation.";
+}
+
+// recoverAsync() makes the SAME kv transaction reusable after a retryable commit
+// conflict: the recovery future completes, the adapter's bookkeeping is reset, and the
+// replayed mutations commit. The retry coordinator relies on this to keep the backend's
+// accumulated backoff across attempts instead of recreating the transaction.
+TEST_F(FDBKVEngineTest, RecoverAsyncReusesTransactionAfterConflict) {
+	const auto key = kv::toBytes("recover_async_key");
+
+	auto txn = kvEngine->createReadWriteTransaction();
+	(void)txn->get(key);  // Put the key in this transaction's read conflict range.
+	{
+		auto external = kvEngine->createReadWriteTransaction();
+		external->set(key, kv::toBytes("external"));
+		ASSERT_TRUE(external->commit());
+	}
+	txn->set(key, kv::toBytes("mine"));
+
+	int commitError = 0;
+	bool retryable = false;
+	ASSERT_FALSE(txn->commitAsync()->getResult(&commitError, &retryable))
+	    << "The external write must conflict with this transaction's read.";
+	ASSERT_TRUE(retryable);
+
+	auto recovery = txn->recoverAsync(commitError);
+	ASSERT_NE(recovery, nullptr);
+	recovery->get();
+	EXPECT_EQ(txn->mutationCount(), uint64_t{0})
+	    << "Recovery resets the adapter's bookkeeping for the replay.";
+
+	// Replay on the same transaction object; this attempt sees the external write.
+	auto observed = txn->get(key);
+	ASSERT_TRUE(observed.has_value());
+	EXPECT_EQ(*observed, kv::toBytes("external"));
+	txn->set(key, kv::toBytes("replayed"));
+	EXPECT_EQ(txn->mutationCount(), uint64_t{1});
+	ASSERT_TRUE(txn->commitAsync()->getResult(&commitError, &retryable));
+
+	{  // Verify the replayed value, then clean up.
+		auto check = kvEngine->createReadWriteTransaction();
+		auto value = check->get(key);
+		ASSERT_TRUE(value.has_value());
+		EXPECT_EQ(*value, kv::toBytes("replayed"));
+		check->remove(key);
+		ASSERT_TRUE(check->commit());
+	}
+}
+
+// recoverAsync() on an adapter whose wrapped transaction has no backend handle is a
+// wrong-state call: it must throw std::logic_error, never return a nullptr future that
+// poses as a started recovery (see the recoverAsync contract in kv/itransaction.h).
+TEST_F(FDBKVEngineTest, RecoverAsyncWithoutBackendHandleThrows) {
+	fdb::FDBTransaction handleless{nullptr};
+	constexpr int kNotCommitted = 1020;  // A retryable code, to isolate the handle check.
+	EXPECT_THROW((void)handleless.recoverAsync(kNotCommitted), std::logic_error);
 }
 
 // getApproximateSize() reports the client-side estimate of the transaction's buffered writes.

--- a/src/fdb/fdb_unittest.cc
+++ b/src/fdb/fdb_unittest.cc
@@ -19,12 +19,16 @@
 #include "common/platform.h"
 
 #include <gtest/gtest.h>
+#include <array>
+#include <atomic>
 #include <chrono>
 #include <cstddef>
 #include <cstdint>
+#include <limits>
 #include <memory>
 #include <stdexcept>
 #include <string>
+#include <string_view>
 #include <thread>
 #include <vector>
 
@@ -1545,8 +1549,10 @@ TEST_F(FDBKVEngineTest, FailedRecommitClearsCommittedVersion) {
 	ASSERT_TRUE(transaction.commit());
 	ASSERT_TRUE(transaction.getCommittedVersion().has_value());
 
-	// Second attempt on the same transaction, failed deterministically before
-	// submission: the version from the first attempt must be gone.
+	// Second attempt on the same transaction (the state machine requires reset()
+	// to leave kCommitted), failed deterministically before submission: the
+	// version from the first attempt must be gone.
+	transaction.reset();
 	fdb::FaultInjection fault;
 	fault.preCommitErrors = {kNotCommitted};
 	transaction.setFaultInjection(&fault);
@@ -1576,6 +1582,8 @@ TEST_F(FDBKVEngineTest, FailedRecommitAsyncClearsCommittedVersion) {
 	ASSERT_TRUE(transaction.commit());
 	ASSERT_TRUE(transaction.getCommittedVersion().has_value());
 
+	// The state machine requires reset() to leave kCommitted before a new attempt.
+	transaction.reset();
 	fdb::FaultInjection fault;
 	fault.preCommitErrors = {kNotCommitted};
 	transaction.setFaultInjection(&fault);
@@ -1618,6 +1626,7 @@ TEST_F(FDBKVEngineTest, TransactionFromNullDBIsInvalidNotUB) {
 	EXPECT_THROW(fromNull.atomicMax(key, value), std::logic_error);
 	EXPECT_THROW(fromNull.remove(key), std::logic_error);
 	EXPECT_THROW(fromNull.removeRange(begin.getKey(), end.getKey()), std::logic_error);
+	EXPECT_THROW(fromNull.addReadConflictKey(key), std::logic_error);
 	EXPECT_THROW(fromNull.commit(), std::logic_error);
 	EXPECT_THROW(fromNull.commitAsync(), std::logic_error);
 	EXPECT_FALSE(fromNull.getCommittedVersion().has_value());
@@ -1640,4 +1649,581 @@ TEST_F(FDBKVEngineTest, ConsumedReadFutureThrowsLogicError) {
 	ASSERT_TRUE(rangeFuture != nullptr);
 	(void)rangeFuture->get();
 	EXPECT_THROW(rangeFuture->get(), std::logic_error);
+}
+
+// ---------------------------------------------------------------------------
+// Transaction state machine (fdb::TransactionState), onErrorAsync, options
+// ---------------------------------------------------------------------------
+
+using fdb::TransactionState;
+
+TEST_F(FDBKVEngineTest, StateCommitAndResetRoundTrip) {
+	fdb::Transaction transaction(fdbDB.get());
+	ASSERT_TRUE(transaction);
+	EXPECT_EQ(transaction.state(), TransactionState::kActive);
+
+	const kv::Key key = kv::toBytes("state_commit_reset");
+	transaction.set(key, kv::toBytes("v1"));
+	ASSERT_TRUE(transaction.commit());
+	EXPECT_EQ(transaction.state(), TransactionState::kCommitted);
+	EXPECT_TRUE(transaction.getCommittedVersion().has_value());
+
+	// Committed forbids further work but allows reset for the next attempt.
+	EXPECT_THROW(transaction.set(key, kv::toBytes("v2")), std::logic_error);
+	transaction.reset();
+	EXPECT_EQ(transaction.state(), TransactionState::kActive);
+	EXPECT_FALSE(transaction.getCommittedVersion().has_value());
+
+	transaction.remove(key);
+	ASSERT_TRUE(transaction.commit());
+}
+
+TEST_F(FDBKVEngineTest, StateRetryableReadErrorEntersRetryPending) {
+	fdb::Transaction transaction(fdbDB.get());
+	ASSERT_TRUE(transaction);
+
+	fdb::FaultInjection fault;
+	fault.readErrors = {kNotCommitted};
+	transaction.setFaultInjection(&fault);
+
+	EXPECT_THROW(transaction.get(kv::toBytes("state_rp")), kv::RetryableTransactionError);
+	EXPECT_EQ(transaction.state(), TransactionState::kRetryPending);
+
+	// A poisoned transaction refuses further work loudly instead of no-opping.
+	EXPECT_THROW(transaction.set(kv::toBytes("k"), kv::toBytes("v")), std::logic_error);
+	EXPECT_THROW(transaction.commit(), std::logic_error);
+	EXPECT_THROW((void)transaction.getAsync(kv::toBytes("k")), std::logic_error);
+	EXPECT_THROW(transaction.addReadConflictKey(kv::toBytes("k")), std::logic_error);
+}
+
+TEST_F(FDBKVEngineTest, StateNonRetryableReadErrorEntersFailedAndResetRevives) {
+	fdb::Transaction transaction(fdbDB.get());
+	ASSERT_TRUE(transaction);
+
+	fdb::FaultInjection fault;
+	fault.readErrors = {kTransactionTooLarge};
+	transaction.setFaultInjection(&fault);
+
+	auto future = transaction.getAsync(kv::toBytes("state_failed"));
+	ASSERT_NE(future, nullptr);
+	EXPECT_THROW(future->get(), kv::TransactionError);
+	EXPECT_EQ(transaction.state(), TransactionState::kFailed);
+
+	transaction.reset();
+	EXPECT_EQ(transaction.state(), TransactionState::kActive);
+	// The same handle is usable again after reset (live read).
+	EXPECT_NO_THROW((void)transaction.get(kv::toBytes("state_failed_absent")));
+}
+
+// A read future issued in one attempt, held unconsumed while reset() starts a FRESH
+// attempt, must not record its late failure into the new attempt: the attempt-generation
+// guard keeps the superseded future inert so it cannot regress kActive.
+TEST_F(FDBKVEngineTest, StaleReadFailureAfterResetLeavesFreshAttemptActive) {
+	fdb::Transaction transaction(fdbDB.get());
+	ASSERT_TRUE(transaction);
+
+	fdb::FaultInjection fault;
+	transaction.setFaultInjection(&fault);
+
+	// Issue a read in the first attempt; hold the future unconsumed.
+	auto stale = transaction.getAsync(kv::toBytes("stale_after_reset"));
+	ASSERT_NE(stale, nullptr);
+
+	// Start a fresh attempt.
+	transaction.reset();
+	ASSERT_EQ(transaction.state(), TransactionState::kActive);
+
+	// The stale future now fails: it must throw to ITS caller but leave the fresh attempt
+	// Active. Without the generation guard it would stamp kRetryPending.
+	fault.readErrors = {kNotCommitted};
+	EXPECT_THROW(stale->get(), kv::RetryableTransactionError);
+	EXPECT_EQ(transaction.state(), TransactionState::kActive);
+}
+
+// The same guard across a successful onErrorAsync() recovery, which re-activates the SAME
+// handle for a fresh attempt: a read future from the recovered-past attempt must not drive
+// the new attempt back out of kActive.
+TEST_F(FDBKVEngineTest, StaleReadFailureAfterRecoveryLeavesFreshAttemptActive) {
+	fdb::Transaction transaction(fdbDB.get());
+	ASSERT_TRUE(transaction);
+
+	fdb::FaultInjection fault;
+	transaction.setFaultInjection(&fault);
+
+	// Issue a read in the first attempt; hold the future unconsumed.
+	auto stale = transaction.getAsync(kv::toBytes("stale_after_recovery"));
+	ASSERT_NE(stale, nullptr);
+
+	// Drive the transaction to a retryable failure, then recover it back to Active.
+	fault.readErrors = {kNotCommitted};
+	EXPECT_THROW((void)transaction.get(kv::toBytes("stale_after_recovery_trigger")),
+	             kv::RetryableTransactionError);
+	ASSERT_EQ(transaction.state(), TransactionState::kRetryPending);
+	auto recovery = transaction.onErrorAsync(kNotCommitted);
+	ASSERT_NE(recovery, nullptr);
+	recovery->get();
+	ASSERT_EQ(transaction.state(), TransactionState::kActive);
+
+	// The stale future (issued before the failure) resolves as a failure now; it must not
+	// regress the recovered attempt.
+	fault.readErrors = {kNotCommitted};
+	EXPECT_THROW(stale->get(), kv::RetryableTransactionError);
+	EXPECT_EQ(transaction.state(), TransactionState::kActive);
+}
+
+TEST_F(FDBKVEngineTest, StatePreCommitConflictEntersRetryPending) {
+	fdb::Transaction transaction(fdbDB.get());
+	ASSERT_TRUE(transaction);
+
+	fdb::FaultInjection fault;
+	fault.preCommitErrors = {kNotCommitted};
+	transaction.setFaultInjection(&fault);
+
+	transaction.set(kv::toBytes("state_precommit"), kv::toBytes("v"));
+	EXPECT_FALSE(transaction.commit());
+	EXPECT_EQ(transaction.state(), TransactionState::kRetryPending);
+}
+
+TEST_F(FDBKVEngineTest, StateMaybeCommittedEntersIndeterminate) {
+	fdb::Transaction transaction(fdbDB.get());
+	ASSERT_TRUE(transaction);
+
+	fdb::FaultInjection fault;
+	fault.postCommitErrors = {kCommitUnknownResult};
+	transaction.setFaultInjection(&fault);
+
+	const kv::Key key = kv::toBytes("state_indeterminate");
+	transaction.set(key, kv::toBytes("v"));
+	EXPECT_FALSE(transaction.commit());
+	EXPECT_EQ(transaction.state(), TransactionState::kIndeterminate);
+
+	// A maybe-committed transaction is destroy-only: no reset, no cancel, no reuse.
+	EXPECT_THROW(transaction.reset(), std::logic_error);
+	EXPECT_THROW(transaction.cancel(), std::logic_error);
+	EXPECT_THROW(transaction.commit(), std::logic_error);
+
+	// The injected override happened after a REAL commit; clean up the key.
+	fdb::Transaction cleanup(fdbDB.get());
+	cleanup.remove(key);
+	ASSERT_TRUE(cleanup.commit());
+}
+
+TEST_F(FDBKVEngineTest, CommitWaitFailureEntersIndeterminate) {
+	fdb::Transaction transaction(fdbDB.get());
+	ASSERT_TRUE(transaction);
+
+	// A wait-layer failure after the commit was submitted: the commit is durable but its
+	// outcome is unknown to us. Injecting not_committed (which classifies as retryable)
+	// proves the wait path forces kIndeterminate regardless of the code, never a resettable
+	// or retryable state that would double-apply.
+	fdb::FaultInjection fault;
+	fault.commitWaitErrors = {kNotCommitted};
+	transaction.setFaultInjection(&fault);
+
+	const kv::Key key = kv::toBytes("state_commit_wait");
+	transaction.set(key, kv::toBytes("v"));
+	EXPECT_FALSE(transaction.commit());
+	EXPECT_EQ(transaction.state(), TransactionState::kIndeterminate);
+
+	EXPECT_THROW(transaction.reset(), std::logic_error);
+	EXPECT_THROW(transaction.cancel(), std::logic_error);
+	EXPECT_THROW(transaction.commit(), std::logic_error);
+
+	// The wait failed after a REAL commit; clean up the key.
+	fdb::Transaction cleanup(fdbDB.get());
+	cleanup.remove(key);
+	ASSERT_TRUE(cleanup.commit());
+}
+
+TEST_F(FDBKVEngineTest, CommitAsyncWaitFailureEntersIndeterminate) {
+	fdb::Transaction transaction(fdbDB.get());
+	ASSERT_TRUE(transaction);
+
+	fdb::FaultInjection fault;
+	fault.commitWaitErrors = {kNotCommitted};
+	transaction.setFaultInjection(&fault);
+
+	const kv::Key key = kv::toBytes("state_commit_async_wait");
+	transaction.set(key, kv::toBytes("v"));
+	auto future = transaction.commitAsync();
+	ASSERT_NE(future, nullptr);
+
+	int error = 0;
+	bool retryable = true;
+	EXPECT_FALSE(future->getResult(&error, &retryable));
+	// Never retryable: a maybe-committed op must not be replayed.
+	EXPECT_FALSE(retryable);
+	EXPECT_EQ(transaction.state(), TransactionState::kIndeterminate);
+	EXPECT_THROW(transaction.reset(), std::logic_error);
+
+	fdb::Transaction cleanup(fdbDB.get());
+	cleanup.remove(key);
+	ASSERT_TRUE(cleanup.commit());
+}
+
+TEST_F(FDBKVEngineTest, StateCommitAsyncTransitions) {
+	fdb::Transaction transaction(fdbDB.get());
+	ASSERT_TRUE(transaction);
+
+	const kv::Key key = kv::toBytes("state_commit_async");
+	transaction.set(key, kv::toBytes("v"));
+	auto future = transaction.commitAsync();
+	ASSERT_NE(future, nullptr);
+	EXPECT_EQ(transaction.state(), TransactionState::kCommitInFlight);
+	// Only the commit future may act while the commit is in flight.
+	EXPECT_THROW(transaction.commit(), std::logic_error);
+	EXPECT_THROW(transaction.reset(), std::logic_error);
+
+	EXPECT_TRUE(future->getResult());
+	EXPECT_EQ(transaction.state(), TransactionState::kCommitted);
+
+	transaction.reset();
+	transaction.remove(key);
+	ASSERT_TRUE(transaction.commit());
+}
+
+TEST_F(FDBKVEngineTest, StateAbandonedCommitFutureEntersIndeterminate) {
+	fdb::Transaction transaction(fdbDB.get());
+	ASSERT_TRUE(transaction);
+
+	const kv::Key key = kv::toBytes("state_abandoned_commit");
+	transaction.set(key, kv::toBytes("v"));
+	{
+		auto future = transaction.commitAsync();
+		ASSERT_NE(future, nullptr);
+		// Destroyed unconsumed: the commit may have applied, so the transaction
+		// must land in the destroy-only Indeterminate state.
+	}
+	EXPECT_EQ(transaction.state(), TransactionState::kIndeterminate);
+	EXPECT_THROW(transaction.reset(), std::logic_error);
+
+	// The abandoned commit may have been durable; remove the key either way.
+	fdb::Transaction cleanup(fdbDB.get());
+	cleanup.remove(key);
+	ASSERT_TRUE(cleanup.commit());
+}
+
+TEST_F(FDBKVEngineTest, OnErrorAsyncRecoversTheSameTransaction) {
+	fdb::Transaction transaction(fdbDB.get());
+	ASSERT_TRUE(transaction);
+
+	fdb::FaultInjection fault;
+	fault.readErrors = {kNotCommitted};
+	transaction.setFaultInjection(&fault);
+
+	EXPECT_THROW(transaction.get(kv::toBytes("state_recover")), kv::RetryableTransactionError);
+	ASSERT_EQ(transaction.state(), TransactionState::kRetryPending);
+
+	auto backoff = transaction.onErrorAsync(kNotCommitted);
+	ASSERT_NE(backoff, nullptr);
+	EXPECT_EQ(transaction.state(), TransactionState::kBackoffInFlight);
+	EXPECT_NO_THROW(backoff->get());
+	EXPECT_EQ(transaction.state(), TransactionState::kActive);
+
+	// The recovered handle must complete a real replay end to end.
+	const kv::Key key = kv::toBytes("state_recover");
+	transaction.set(key, kv::toBytes("v"));
+	ASSERT_TRUE(transaction.commit());
+
+	fdb::Transaction verify(fdbDB.get());
+	auto got = verify.get(key);
+	ASSERT_TRUE(got.has_value());
+	EXPECT_EQ(*got, kv::toBytes("v"));
+	verify.reset();
+	verify.remove(key);
+	ASSERT_TRUE(verify.commit());
+}
+
+TEST_F(FDBKVEngineTest, OnErrorAsyncAbandonedFutureIsDestroyOnly) {
+	fdb::Transaction transaction(fdbDB.get());
+	ASSERT_TRUE(transaction);
+
+	fdb::FaultInjection fault;
+	fault.readErrors = {kNotCommitted};
+	transaction.setFaultInjection(&fault);
+
+	EXPECT_THROW(transaction.get(kv::toBytes("state_abandoned_backoff")),
+	             kv::RetryableTransactionError);
+	{
+		auto backoff = transaction.onErrorAsync(kNotCommitted);
+		ASSERT_NE(backoff, nullptr);
+		// Destroyed unconsumed: the recovery outcome is unknown, reuse is unsafe
+		// and reset-during-on_error is undefined in FDB.
+	}
+	EXPECT_EQ(transaction.state(), TransactionState::kFailed);
+	EXPECT_THROW(transaction.reset(), std::logic_error);
+	EXPECT_THROW(transaction.cancel(), std::logic_error);
+}
+
+TEST_F(FDBKVEngineTest, OnErrorAsyncArgumentAndStateChecks) {
+	fdb::Transaction transaction(fdbDB.get());
+	ASSERT_TRUE(transaction);
+
+	EXPECT_THROW((void)transaction.onErrorAsync(0), std::invalid_argument);
+	// Only a surfaced retryable failure (kRetryPending) permits backend recovery.
+	EXPECT_THROW((void)transaction.onErrorAsync(kNotCommitted), std::logic_error);
+}
+
+TEST_F(FDBKVEngineTest, OnErrorAsyncRejectsForeignErrorCode) {
+	fdb::Transaction transaction(fdbDB.get());
+	ASSERT_TRUE(transaction);
+
+	fdb::FaultInjection fault;
+	fault.readErrors = {kNotCommitted};
+	transaction.setFaultInjection(&fault);
+	EXPECT_THROW(transaction.get(kv::toBytes("foreign_code")), kv::RetryableTransactionError);
+	ASSERT_EQ(transaction.state(), TransactionState::kRetryPending);
+
+	// A code this transaction never surfaced would drive FDB's retry classification
+	// and backoff with someone else's failure; only the recorded code is accepted.
+	constexpr fdb_error_t kTransactionTooOld = 1007;
+	EXPECT_THROW((void)transaction.onErrorAsync(kTransactionTooOld), std::invalid_argument);
+	EXPECT_EQ(transaction.state(), TransactionState::kRetryPending);
+
+	auto backoff = transaction.onErrorAsync(kNotCommitted);
+	ASSERT_NE(backoff, nullptr);
+	EXPECT_NO_THROW(backoff->get());
+	EXPECT_EQ(transaction.state(), TransactionState::kActive);
+}
+
+TEST_F(FDBKVEngineTest, LateReadFailureDoesNotRegressCommitted) {
+	fdb::Transaction transaction(fdbDB.get());
+	ASSERT_TRUE(transaction);
+
+	fdb::FaultInjection fault;
+	transaction.setFaultInjection(&fault);
+
+	const kv::Key key = kv::toBytes("late_read_committed");
+	auto pending = transaction.getAsync(kv::toBytes("late_read_committed_other"));
+	ASSERT_NE(pending, nullptr);
+	transaction.set(key, kv::toBytes("v"));
+	ASSERT_TRUE(transaction.commit());
+	ASSERT_EQ(transaction.state(), TransactionState::kCommitted);
+
+	// The pre-commit read resolves late and fails: it must throw, but it must not
+	// regress the commit outcome into a replayable state (a replay would double-apply).
+	fault.readErrors = {kNotCommitted};
+	EXPECT_THROW((void)pending->get(), kv::RetryableTransactionError);
+	EXPECT_EQ(transaction.state(), TransactionState::kCommitted);
+
+	transaction.reset();
+	transaction.remove(key);
+	ASSERT_TRUE(transaction.commit());
+}
+
+TEST_F(FDBKVEngineTest, LateReadFailureDoesNotRegressIndeterminate) {
+	fdb::Transaction transaction(fdbDB.get());
+	ASSERT_TRUE(transaction);
+
+	fdb::FaultInjection fault;
+	fault.postCommitErrors = {kCommitUnknownResult};
+	transaction.setFaultInjection(&fault);
+
+	const kv::Key key = kv::toBytes("late_read_indeterminate");
+	auto pending = transaction.getAsync(kv::toBytes("late_read_indeterminate_other"));
+	ASSERT_NE(pending, nullptr);
+	transaction.set(key, kv::toBytes("v"));
+	EXPECT_FALSE(transaction.commit());
+	ASSERT_EQ(transaction.state(), TransactionState::kIndeterminate);
+
+	// A late failed read must not turn a maybe-committed transaction replayable.
+	fault.readErrors = {kNotCommitted};
+	EXPECT_THROW((void)pending->get(), kv::RetryableTransactionError);
+	EXPECT_EQ(transaction.state(), TransactionState::kIndeterminate);
+	EXPECT_THROW(transaction.reset(), std::logic_error);
+
+	// The injected override happened after a REAL commit; clean up the key.
+	fdb::Transaction cleanup(fdbDB.get());
+	cleanup.remove(key);
+	ASSERT_TRUE(cleanup.commit());
+}
+
+TEST_F(FDBKVEngineTest, GetApproximateSizeReportsOnlyWhileActive) {
+	fdb::Transaction transaction(fdbDB.get());
+	ASSERT_TRUE(transaction);
+
+	const kv::Key key = kv::toBytes("approx_size_states");
+	transaction.set(key, kv::toBytes("v"));
+	EXPECT_TRUE(transaction.getApproximateSize().has_value());
+
+	auto future = transaction.commitAsync();
+	ASSERT_NE(future, nullptr);
+	// In-flight and post-commit states are owned by their futures; the buffered-mutation
+	// estimate is meaningless there, so the diagnostic reports "no estimate".
+	EXPECT_EQ(transaction.state(), TransactionState::kCommitInFlight);
+	EXPECT_EQ(transaction.getApproximateSize(), std::nullopt);
+	ASSERT_TRUE(future->getResult());
+	EXPECT_EQ(transaction.state(), TransactionState::kCommitted);
+	EXPECT_EQ(transaction.getApproximateSize(), std::nullopt);
+
+	transaction.reset();
+	EXPECT_TRUE(transaction.getApproximateSize().has_value());
+	transaction.remove(key);
+	ASSERT_TRUE(transaction.commit());
+}
+
+TEST_F(FDBKVEngineTest, VoidFutureIsSingleUse) {
+	fdb::Transaction transaction(fdbDB.get());
+	ASSERT_TRUE(transaction);
+
+	fdb::FaultInjection fault;
+	fault.readErrors = {kNotCommitted};
+	transaction.setFaultInjection(&fault);
+
+	EXPECT_THROW(transaction.get(kv::toBytes("state_single_use")), kv::RetryableTransactionError);
+	auto backoff = transaction.onErrorAsync(kNotCommitted);
+	ASSERT_NE(backoff, nullptr);
+	EXPECT_NO_THROW(backoff->get());
+	EXPECT_THROW(backoff->get(), std::logic_error);
+}
+
+TEST_F(FDBKVEngineTest, CancelEntersCancelledAndResetRevives) {
+	fdb::Transaction transaction(fdbDB.get());
+	ASSERT_TRUE(transaction);
+
+	transaction.cancel();
+	EXPECT_EQ(transaction.state(), TransactionState::kCancelled);
+	EXPECT_EQ(transaction.error(), kTransactionCancelled);
+	EXPECT_THROW((void)transaction.get(kv::toBytes("state_cancel")), std::logic_error);
+	EXPECT_THROW(transaction.cancel(), std::logic_error);
+
+	transaction.reset();
+	EXPECT_EQ(transaction.state(), TransactionState::kActive);
+	EXPECT_NO_THROW((void)transaction.get(kv::toBytes("state_cancel_absent")));
+}
+
+TEST_F(FDBKVEngineTest, DestroyingArmedUnreadyFutureFiresCallback) {
+	// Pins the fdb_c lifetime semantics armReadyCallback (fdb.cc) relies on: destroying
+	// a not-yet-ready future cancels it, cancellation makes it ready, and the armed
+	// callback fires exactly once, releasing the heap node. A watch on a key nobody
+	// writes is the one future that stays unready indefinitely, so it isolates the
+	// destroy-before-ready path deterministically.
+	FDBTransaction *rawTr = nullptr;
+	ASSERT_EQ(fdb_database_create_transaction(fdbDB->getDB(), &rawTr), 0);
+	const kv::Key key = kv::toBytes("armed_callback_never_written");
+	FDBFuture *watch = fdb_transaction_watch(rawTr, key.data(), static_cast<int>(key.size()));
+	ASSERT_NE(watch, nullptr);
+	// A watch only becomes durable once its transaction commits.
+	FDBFuture *commitFuture = fdb_transaction_commit(rawTr);
+	ASSERT_EQ(fdb_future_block_until_ready(commitFuture), 0);
+	ASSERT_EQ(fdb_future_get_error(commitFuture), 0);
+	fdb_future_destroy(commitFuture);
+	ASSERT_EQ(fdb_future_is_ready(watch), 0) << "watch resolved early; experiment invalid";
+
+	static std::atomic<int> fired;
+	fired = 0;
+	ASSERT_EQ(
+	    fdb_future_set_callback(
+	        watch, [](FDBFuture * /*future*/, void * /*param*/) { fired.fetch_add(1); }, nullptr),
+	    0);
+	fdb_future_destroy(watch);
+
+	// The callback runs on the FDB network thread; wait bounded.
+	const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(2);
+	while (fired.load() == 0 && std::chrono::steady_clock::now() < deadline) {
+		std::this_thread::sleep_for(std::chrono::milliseconds(1));
+	}
+	EXPECT_EQ(fired.load(), 1);
+	fdb_transaction_destroy(rawTr);
+}
+
+TEST(FdbIntOptionEncodingTest, EncodesLittleEndian) {
+	const auto bytes = fdb::detail::encodeInt64LE(0x0102030405060708);
+	const std::array<uint8_t, 8> expected{0x08, 0x07, 0x06, 0x05, 0x04, 0x03, 0x02, 0x01};
+	EXPECT_EQ(bytes, expected);
+	const auto minusOne = fdb::detail::encodeInt64LE(-1);
+	for (uint8_t byte : minusOne) { EXPECT_EQ(byte, 0xFF); }
+}
+
+TEST_F(FDBKVEngineTest, SetMaxRetryDelayValidatesAndApplies) {
+	fdb::Transaction transaction(fdbDB.get());
+	ASSERT_TRUE(transaction);
+
+	EXPECT_THROW(transaction.setMaxRetryDelayMs(-1), std::invalid_argument);
+	// The FDB option range is [0, INT_MAX]; a larger value is the caller's bug and
+	// must not reach the backend (where it would surface as a TransactionError).
+	EXPECT_THROW(
+	    transaction.setMaxRetryDelayMs(static_cast<int64_t>(std::numeric_limits<int>::max()) + 1),
+	    std::invalid_argument);
+	EXPECT_EQ(transaction.state(), TransactionState::kActive);
+	EXPECT_NO_THROW(transaction.setMaxRetryDelayMs(1000));
+	// Sticky: survives reset (re-applied internally; a live backend rejection would
+	// throw here).
+	EXPECT_NO_THROW(transaction.reset());
+	EXPECT_EQ(transaction.state(), TransactionState::kActive);
+}
+
+TEST_F(FDBKVEngineTest, SetTimeoutValidatesAndApplies) {
+	fdb::Transaction transaction(fdbDB.get());
+	ASSERT_TRUE(transaction);
+
+	EXPECT_THROW(transaction.setTimeoutMs(-1), std::invalid_argument);
+	// The valid range is (0, INT_MAX]. 0 is rejected (FDB would read it as "disable the
+	// timeout", the opposite of bounding), and a larger value is the caller's bug; neither
+	// may reach the backend (where it would surface as a TransactionError).
+	EXPECT_THROW(transaction.setTimeoutMs(0), std::invalid_argument);
+	EXPECT_THROW(
+	    transaction.setTimeoutMs(static_cast<int64_t>(std::numeric_limits<int>::max()) + 1),
+	    std::invalid_argument);
+	EXPECT_EQ(transaction.state(), TransactionState::kActive);
+	EXPECT_NO_THROW(transaction.setTimeoutMs(5000));
+	// Sticky like max_retry_delay: survives reset (re-applied internally; a live backend
+	// rejection would throw here).
+	EXPECT_NO_THROW(transaction.reset());
+	EXPECT_EQ(transaction.state(), TransactionState::kActive);
+}
+
+TEST_F(FDBKVEngineTest, OptionsPersistAcrossOnErrorAndRevertOnReset) {
+	// Live contract test for the FDB option lifetime the retry design relies on:
+	// options persist across on_error but revert on reset. Observable via
+	// retry_limit=1: the first backend recovery succeeds, the second fails ONLY if
+	// the option survived the first on_error; after reset the limit is gone and
+	// recovery succeeds again.
+	fdb::Transaction transaction(fdbDB.get());
+	ASSERT_TRUE(transaction);
+
+	const auto limit = fdb::detail::encodeInt64LE(1);
+	const std::string_view limitValue(reinterpret_cast<const char *>(limit.data()), limit.size());
+	ASSERT_EQ(transaction.setOption(FDB_TR_OPTION_RETRY_LIMIT, limitValue), 0);
+
+	fdb::FaultInjection fault;
+	fault.readErrors = {kNotCommitted, kNotCommitted, kNotCommitted};
+	transaction.setFaultInjection(&fault);
+
+	EXPECT_THROW(transaction.get(kv::toBytes("opt_persist")), kv::RetryableTransactionError);
+	auto first = transaction.onErrorAsync(kNotCommitted);
+	ASSERT_NE(first, nullptr);
+	EXPECT_NO_THROW(first->get());
+
+	EXPECT_THROW(transaction.get(kv::toBytes("opt_persist")), kv::RetryableTransactionError);
+	auto second = transaction.onErrorAsync(kNotCommitted);
+	ASSERT_NE(second, nullptr);
+	// retry_limit=1 persisted across the first recovery, so the second one fails
+	// and the transaction is terminal.
+	EXPECT_THROW(second->get(), kv::TransactionError);
+	EXPECT_EQ(transaction.state(), TransactionState::kFailed);
+	// A failed recovery is destroy-only: the transaction cannot be reset and reused.
+	EXPECT_THROW(transaction.reset(), std::logic_error);
+
+	// Revert on reset, shown on a fresh transaction: a reset from a legal (non-terminal)
+	// state clears retry_limit back to its default, so a later recovery is no longer bounded
+	// and succeeds where the already-consumed budget would otherwise fail.
+	fdb::Transaction reused(fdbDB.get());
+	ASSERT_TRUE(reused);
+	ASSERT_EQ(reused.setOption(FDB_TR_OPTION_RETRY_LIMIT, limitValue), 0);
+	fdb::FaultInjection revertFault;
+	revertFault.readErrors = {kNotCommitted, kNotCommitted};
+	reused.setFaultInjection(&revertFault);
+
+	EXPECT_THROW(reused.get(kv::toBytes("opt_revert")), kv::RetryableTransactionError);
+	auto beforeReset = reused.onErrorAsync(kNotCommitted);
+	ASSERT_NE(beforeReset, nullptr);
+	EXPECT_NO_THROW(beforeReset->get());  // consumes the single retry the limit allows
+
+	reused.reset();  // legal from kActive; reverts retry_limit to the default
+	EXPECT_THROW(reused.get(kv::toBytes("opt_revert")), kv::RetryableTransactionError);
+	auto afterReset = reused.onErrorAsync(kNotCommitted);
+	ASSERT_NE(afterReset, nullptr);
+	EXPECT_NO_THROW(afterReset->get());  // succeeds only because the limit reverted
+	EXPECT_EQ(reused.state(), TransactionState::kActive);
 }

--- a/src/kv/ifuture.h
+++ b/src/kv/ifuture.h
@@ -237,6 +237,41 @@ protected:
 	IVoidFuture() = default;
 };
 
+/// Trivial already-completed void future, for backends whose recovery (or watch)
+/// completes synchronously: in-memory backends, test mocks, and synthesized failures.
+class ImmediateVoidFuture final : public IVoidFuture {
+public:
+	/// Successful outcome.
+	ImmediateVoidFuture() = default;
+
+	/// Failed outcome: get() throws a TransactionError with this code, the retryable
+	/// subclass when `retryable` is set.
+	ImmediateVoidFuture(int errorCode, bool retryable, std::string message)
+	    : errorCode_(errorCode), retryable_(retryable), message_(std::move(message)) {}
+
+	bool isReady() override { return true; }
+
+	void setReadyCallback(void (*callback)(void *), void *arg) override {
+		if (callback != nullptr) { callback(arg); }
+	}
+
+	void get() override {
+		if (consumed_) {
+			throw TransactionStateError("ImmediateVoidFuture::get: future already consumed");
+		}
+		consumed_ = true;
+		if (errorCode_ == 0) { return; }
+		if (retryable_) { throw RetryableTransactionError(errorCode_, message_); }
+		throw TransactionError(errorCode_, message_);
+	}
+
+private:
+	int errorCode_ = 0;
+	bool retryable_ = false;
+	std::string message_;
+	bool consumed_ = false;
+};
+
 /// Trivial already-completed commit future, for backends that commit synchronously
 /// (in-memory Master, test mocks). Keeps the deferred-commit code path uniform.
 class ImmediateCommitFuture final : public ICommitFuture {

--- a/src/kv/ifuture.h
+++ b/src/kv/ifuture.h
@@ -23,6 +23,7 @@
 #include <optional>
 #include <stdexcept>
 #include <string>
+#include <utility>
 
 #include "kv/kv_types.h"
 
@@ -35,7 +36,7 @@ namespace kv {
 ///  - Backend failures (the operation reached the backend and failed there) are reported
 ///    as a TransactionError; retryable() says whether the caller may replay the op.
 ///  - Invalid argument values (e.g. a bad versionstamp offset) are std::invalid_argument.
-///  - Calls in the wrong transaction state are std::logic_error.
+///  - Calls in the wrong transaction state throw TransactionStateError (a std::logic_error).
 /// The local domains carry no backend error code, so they can never be mistaken for (or
 /// fed into) backend retry handling.
 ///
@@ -70,6 +71,19 @@ public:
 	    : TransactionError(errorCode, message) {}
 
 	bool retryable() const noexcept override { return true; }
+};
+
+/// Thrown when a transaction or one of its single-use futures is called in the wrong state:
+/// no backend handle, an illegal lifecycle state (e.g. reset/cancel while a commit is in
+/// flight, or on a maybe-committed transaction), or a future consumed twice. This is a
+/// coordinator SEQUENCING bug, distinct from a backend TransactionError (which carries a
+/// backend code) and from the arbitrary std::logic_error subclasses (std::out_of_range,
+/// std::length_error, ...) unrelated caller code may raise. It derives std::logic_error so
+/// existing catch(std::logic_error) sites stay valid; a retry harness can catch THIS type
+/// alone to contain its own sequencing bugs while letting genuine caller logic bugs escape.
+class TransactionStateError : public std::logic_error {
+public:
+	explicit TransactionStateError(const std::string &message) : std::logic_error(message) {}
 };
 
 /// Interface for asynchronous future results from key-value operations.
@@ -186,6 +200,41 @@ public:
 
 protected:
 	ICommitFuture() = default;
+};
+
+/// Interface for an asynchronous operation that yields no value, only success or a
+/// typed failure (e.g. backend recovery between retry attempts, watches).
+///
+/// @note Single-use: get() may be called only once.
+/// @note The transaction that produced this future must stay alive until get() returns
+///   (or until the future is destroyed, whichever comes first).
+class IVoidFuture {
+public:
+	virtual ~IVoidFuture() = default;
+
+	// Non-copyable, non-movable
+	IVoidFuture(const IVoidFuture &) = delete;
+	IVoidFuture &operator=(const IVoidFuture &) = delete;
+	IVoidFuture(IVoidFuture &&) = delete;
+	IVoidFuture &operator=(IVoidFuture &&) = delete;
+
+	/// Checks whether the result is available without blocking.
+	virtual bool isReady() = 0;
+
+	/// Registers a one-shot wakeup fired when the result becomes ready. Same contract
+	/// as ICommitFuture::setReadyCallback: may fire immediately and inline, may run on
+	/// another thread, must not touch this future or its transaction; best-effort.
+	virtual void setReadyCallback(void (*callback)(void *), void *arg) = 0;
+
+	/// Blocks until the result is ready. Returns normally on success.
+	/// @throws RetryableTransactionError when the operation failed with a retryable
+	///   backend error.
+	/// @throws TransactionError when it failed with any other backend error.
+	/// @throws std::logic_error when called more than once (single-use).
+	virtual void get() = 0;
+
+protected:
+	IVoidFuture() = default;
 };
 
 /// Trivial already-completed commit future, for backends that commit synchronously

--- a/src/kv/itransaction.h
+++ b/src/kv/itransaction.h
@@ -32,6 +32,7 @@ namespace kv {
 class IFuture;
 class IRangeFuture;
 class ICommitFuture;
+class IVoidFuture;
 
 /// Represents a key selector for range queries.
 class KeySelector {
@@ -139,7 +140,7 @@ protected:
 /// Inherits from IReadOnlyTransaction and adds methods for modifying the database.
 /// Per the error-domain rules in kv/ifuture.h, backend failures throw the
 /// TransactionError family and wrong-state calls (e.g. operations on a moved-from
-/// backend transaction) throw std::logic_error; a write is never silently dropped.
+/// backend transaction) throw TransactionStateError; a write is never silently dropped.
 class IReadWriteTransaction : public IReadOnlyTransaction {
 public:
 	virtual ~IReadWriteTransaction() override = default;
@@ -217,6 +218,37 @@ public:
 	/// report it (callers then fall back to a count-based bound). Computed client-side, so it
 	/// is cheap to poll while applying a batch.
 	virtual std::optional<uint64_t> getApproximateSize() const { return std::nullopt; }
+
+	/// Begins backend recovery after a retryable error so this SAME transaction object
+	/// can be reused for a replay (backends with server-paced backoff, like
+	/// FoundationDB's on_error, accumulate their delay in the transaction; recreating
+	/// it on every attempt loses that pacing).
+	/// Contract:
+	///  - backendErrorCode must be the code this transaction just surfaced via a
+	///    kv::TransactionError with retryable() == true. Calling without such a
+	///    surfaced error is a std::logic_error; a zero code is a std::invalid_argument.
+	///  - The caller owns the transaction while the future is outstanding; no other
+	///    operation may be issued on it.
+	///  - get() returning normally guarantees the transaction is reusable, with the
+	///    implementation's bookkeeping (mutation count, committed version) reset.
+	///  - get() throwing means the transaction is terminal; destroy it and retry on a
+	///    fresh transaction if the thrown error is retryable.
+	///  - Destroying the future without get() leaves the transaction terminal.
+	///  - Never returns nullptr; wrong-state calls throw TransactionStateError per the
+	///    class contract.
+	/// In-memory backends have no recovery work and return an immediately-successful
+	/// future; all retry pacing then comes from the caller.
+	virtual std::unique_ptr<IVoidFuture> recoverAsync(int backendErrorCode) = 0;
+
+	/// Bounds the total time this transaction may block (reads and commit) before the
+	/// backend auto-cancels it, in milliseconds. The bound persists across recoverAsync()
+	/// retries (like FoundationDB's transaction TIMEOUT option, measured from this call),
+	/// so a caller with its own wall-clock retry deadline sets the remaining budget here
+	/// and a stuck backend cannot block the caller's thread past it. Pass a positive value;
+	/// a non-positive one is a caller error (0 would DISABLE the timeout on backends like
+	/// FDB, the opposite of bounding) and may throw. Backends without a timeout concept
+	/// (in-memory) do not block on a cluster and ignore it; the default is a no-op.
+	virtual void setTimeoutMs(int /*milliseconds*/) {}
 
 protected:
 	IReadWriteTransaction() = default;

--- a/src/kv/transaction_error_unittest.cc
+++ b/src/kv/transaction_error_unittest.cc
@@ -20,6 +20,8 @@
 
 #include <gtest/gtest.h>
 
+#include <stdexcept>
+
 #include "kv/ifuture.h"
 
 namespace {
@@ -68,5 +70,47 @@ TEST(KVTransactionErrorTest, CatchingRetryableSkipsBase) {
 		caughtRetryable = true;
 	} catch (const kv::TransactionError &) { caughtBase = true; }
 	EXPECT_FALSE(caughtRetryable);
+	EXPECT_TRUE(caughtBase);
+}
+
+TEST(KVImmediateVoidFutureTest, SuccessIsReadyAndSingleUse) {
+	kv::ImmediateVoidFuture future;
+	EXPECT_TRUE(future.isReady());
+
+	// An already-completed future must invoke a freshly installed callback inline,
+	// or a poller that arms it after completion would wait forever.
+	bool called = false;
+	future.setReadyCallback([](void *arg) { *static_cast<bool *>(arg) = true; }, &called);
+	EXPECT_TRUE(called);
+
+	future.get();
+	// A consumed-future reuse is a coordinator sequencing bug: TransactionStateError, which
+	// derives std::logic_error so both the narrow type and the base match.
+	EXPECT_THROW(future.get(), kv::TransactionStateError) << "get() consumes the future.";
+	EXPECT_THROW(future.get(), std::logic_error) << "TransactionStateError is a std::logic_error.";
+}
+
+TEST(KVImmediateVoidFutureTest, ScriptedFailureThrowsMatchingType) {
+	kv::ImmediateVoidFuture retryable(kNotCommitted, true, "not committed");
+	try {
+		retryable.get();
+		FAIL() << "A scripted failure must throw.";
+	} catch (const kv::RetryableTransactionError &error) {
+		EXPECT_EQ(error.errorCode(), kNotCommitted);
+		EXPECT_STREQ(error.what(), "not committed");
+	}
+
+	kv::ImmediateVoidFuture fatal(kTransactionTooLarge, false, "transaction too large");
+	bool caughtRetryable = false;
+	bool caughtBase = false;
+	try {
+		fatal.get();
+	} catch (const kv::RetryableTransactionError &) {
+		caughtRetryable = true;
+	} catch (const kv::TransactionError &error) {
+		caughtBase = true;
+		EXPECT_EQ(error.errorCode(), kTransactionTooLarge);
+	}
+	EXPECT_FALSE(caughtRetryable) << "A non-retryable scripted failure must throw the base type.";
 	EXPECT_TRUE(caughtBase);
 }

--- a/src/master/filesystem_operation_context.cc
+++ b/src/master/filesystem_operation_context.cc
@@ -50,3 +50,9 @@ kv::IReadOnlyTransaction *FilesystemOperationContext::getReadOnlyTransaction() c
 kv::IReadWriteTransaction *FilesystemOperationContext::getReadWriteTransaction() const {
 	return rwTransaction_.get();
 }
+
+std::unique_ptr<kv::IReadWriteTransaction>
+FilesystemOperationContext::releaseReadWriteTransaction() {
+	if (rwTransaction_ != nullptr) { transactionType_ = TransactionType::kNone; }
+	return std::move(rwTransaction_);
+}

--- a/src/master/filesystem_operation_context.h
+++ b/src/master/filesystem_operation_context.h
@@ -97,6 +97,14 @@ public:
 	/// Get the read-write transaction (null if none or read-only)
 	kv::IReadWriteTransaction *getReadWriteTransaction() const;
 
+	/// Relinquishes ownership of the read-write transaction (nullptr if none). Used by
+	/// the retry coordinator to retain the transaction across attempts (backend
+	/// recovery keeps its accumulated backoff) while this context, with all its
+	/// attempt-scoped state (arena, deferred changelog buffer, confirmation flag), is
+	/// discarded. After this call the context has no transaction and should only be
+	/// destroyed.
+	std::unique_ptr<kv::IReadWriteTransaction> releaseReadWriteTransaction();
+
 	/// Get the transaction type hint
 	TransactionType getTransactionType() const { return transactionType_; }
 

--- a/src/master/matoclserv.cc
+++ b/src/master/matoclserv.cc
@@ -425,6 +425,7 @@ static BlockingRecoveryResult matoclserv_recover_transaction_blocking(
     std::chrono::steady_clock::time_point deadline) {
 	auto txn = ctx.releaseReadWriteTransaction();
 	if (txn == nullptr) { return {}; }
+
 	// TEST-ONLY: simulate a retryable recovery failure (the transaction is dropped
 	// unrecovered, like the real failure below) to force the paced fresh-replay path.
 	static uint32_t injectedRecoveryFailures = 0;
@@ -435,10 +436,12 @@ static BlockingRecoveryResult matoclserv_recover_transaction_blocking(
 		    injectedRecoveryFailures);
 		return {};
 	}
+
 	auto recovery = txn->recoverAsync(errorCode);
 	// recoverAsync never returns nullptr (it throws on a wrong-state call), so a null future is
 	// a library contract violation; fail-stop loudly instead of masking it as a fresh replay.
 	massert(recovery != nullptr, "recoverAsync returned a nullptr future");
+
 	// Bounded blocking wait: the network thread fail-stops on death, so recovery cannot
 	// hang forever, but it can still block the event loop for a backend timeout. Spin on
 	// isReady() so the stall is capped by the shared retry deadline; past it, give the op up.
@@ -450,6 +453,7 @@ static BlockingRecoveryResult matoclserv_recover_transaction_blocking(
 		}
 		std::this_thread::sleep_for(std::chrono::milliseconds(1));
 	}
+
 	try {
 		recovery->get();
 		return {std::move(txn), false};

--- a/src/master/matoclserv.cc
+++ b/src/master/matoclserv.cc
@@ -42,11 +42,15 @@
 #include <algorithm>
 #include <atomic>
 #include <bit>
+#include <chrono>
 #include <cstdint>
 #include <deque>
 #include <fstream>
 #include <functional>
 #include <memory>
+#include <random>
+#include <stdexcept>
+#include <thread>
 
 #include "common/charts.h"
 #include "common/chunk_type_with_address.h"
@@ -268,6 +272,11 @@ static uint32_t gDebugInjectConflicts = 0;
 // inode is burned. N < MATOCL_MAX_COMMIT_RETRIES recovers; N >= it exhausts to a bounded
 // EIO with no abort. Reloadable. Leave 0 in production.
 static uint32_t gDebugInjectReadConflicts = 0;
+// TEST-ONLY fault injection (MATOCL_DEBUG_INJECT_RECOVERY_ERRORS, default 0): make the
+// first N blocking backend recoveries report a retryable failure (the transaction is
+// dropped unrecovered), forcing the paced fresh-transaction replay path of the sync
+// retry loop. Counted per process. Reloadable. Leave 0 in production.
+static uint32_t gDebugInjectRecoveryErrors = 0;
 
 // eventfd the commit future's ready callback writes to (from the backend network
 // thread, or inline from the event-loop thread) so poll() wakes immediately to
@@ -353,67 +362,261 @@ static void matoclserv_commit_confirmed(const FilesystemOperationContext &ctx) {
 	matoclserv_publish_deferred_changelog(ctx);
 }
 
-/// Runs a replayable op on a fresh read-write transaction and commits synchronously.
-/// Retryable body reads and retryable commit conflicts replay the whole body on a
-/// new transaction, bounded by gMaxCommitRetries. Non-OK body status returns without
-/// commit; non-retryable commit failure or retry exhaustion returns SAUNAFS_ERROR_IO.
-/// Unknown commit result is not replayed because it may have applied already; replay
-/// could double-apply. Used by standalone post-durability cleanups outside the group
-/// batch because they can conflict with batched commits on the same inode. The body
-/// must rebuild out state each attempt and defer persistent in-memory side effects
-/// until OK. Without a read-write transaction, the body has already applied in place.
-static uint8_t matoclserv_commit_op_with_retry(const OpReplay &body) {
+/// Replay pacing for fresh-transaction replays (the sync retry loop and the timed
+/// BatchRetry flavor), mirroring the backend's own series: 10ms doubled per attempt,
+/// with the base capped at 1s and then jittered x[0.8, 1.2] (so up to ~1.2s), so
+/// replays of independent conflicts do not lockstep. Event-loop thread only (plain
+/// static locals).
+static std::chrono::milliseconds matoclserv_replay_delay(uint32_t attempt) {
+	constexpr int64_t kBaseMs = 10;
+	constexpr int64_t kMaxMs = 1000;
+	const uint32_t doublings = std::min(attempt > 0 ? attempt - 1 : 0, 7U);
+	static std::mt19937 rng{std::random_device{}()};
+	static std::uniform_real_distribution<double> jitter(0.8, 1.2);
+	const auto delayMs = static_cast<int64_t>(
+	    static_cast<double>(std::min(kBaseMs << doublings, kMaxMs)) * jitter(rng));
+	return std::chrono::milliseconds(delayMs);
+}
+
+/// Wall-clock ceiling on one synchronous retry loop. The sync path runs on the event-loop
+/// thread, and its recovery waits and pacing sleeps block it, so the whole loop is capped
+/// here (mirroring the batch path's kBatchRecoveryDeadline): past the deadline the op fails
+/// with EIO rather than stall the loop further. This bounds, but does not remove, the
+/// stall; the non-blocking redesign (park like the batch path) is a separate follow-up.
+static constexpr std::chrono::seconds kSyncRetryDeadline{10};
+
+/// Sleeps for the paced replay delay but never past `deadline`, so a fresh-replay pace
+/// cannot push the event-loop stall beyond the retry budget.
+static void matoclserv_sleep_bounded(std::chrono::milliseconds delay,
+                                     std::chrono::steady_clock::time_point deadline) {
+	const auto now = std::chrono::steady_clock::now();
+	if (now >= deadline) { return; }
+	const auto remaining = std::chrono::duration_cast<std::chrono::milliseconds>(deadline - now);
+	std::this_thread::sleep_for(std::min(delay, remaining));
+}
+
+/// Milliseconds left until `deadline`, as an FDB transaction-timeout value: the whole
+/// budget is < kSyncRetryDeadline so it fits an int, and it is clamped to at least 1 so a
+/// stale or just-crossed deadline never yields 0 (which FDB reads as "disable the
+/// timeout", the opposite of what a spent budget wants).
+static int matoclserv_remaining_ms(std::chrono::steady_clock::time_point deadline) {
+	const auto remaining = std::chrono::duration_cast<std::chrono::milliseconds>(
+	                           deadline - std::chrono::steady_clock::now())
+	                           .count();
+	return static_cast<int>(std::max<int64_t>(remaining, 1));
+}
+
+/// Outcome of a blocking backend recovery attempt (sync retry path). txn non-null:
+/// replay on the SAME recovered transaction. txn null with giveUp false: no recovery
+/// available or it failed retryably; the caller replays on a fresh transaction with
+/// its own pacing. giveUp true: recovery failed non-retryably, fail the op.
+struct BlockingRecoveryResult {
+	std::unique_ptr<kv::IReadWriteTransaction> txn;
+	bool giveUp = false;
+};
+
+/// Blocking backend recovery of ctx's transaction after a retryable failure, so the
+/// SAME transaction can be replayed with the backend's accumulated backoff (the
+/// blocking wait IS that backoff). Outcomes are classified as in BlockingRecoveryResult.
+/// Used by the synchronous retry path only; the batch coordinator recovers without
+/// blocking via the wakeup eventfd.
+static BlockingRecoveryResult matoclserv_recover_transaction_blocking(
+    FilesystemOperationContext &ctx, int errorCode,
+    std::chrono::steady_clock::time_point deadline) {
+	auto txn = ctx.releaseReadWriteTransaction();
+	if (txn == nullptr) { return {}; }
+	// TEST-ONLY: simulate a retryable recovery failure (the transaction is dropped
+	// unrecovered, like the real failure below) to force the paced fresh-replay path.
+	static uint32_t injectedRecoveryFailures = 0;
+	if (injectedRecoveryFailures < gDebugInjectRecoveryErrors) {
+		++injectedRecoveryFailures;
+		safs::log_info(
+		    "matoclserv: injected recovery failure {} (MATOCL_DEBUG_INJECT_RECOVERY_ERRORS)",
+		    injectedRecoveryFailures);
+		return {};
+	}
+	auto recovery = txn->recoverAsync(errorCode);
+	// recoverAsync never returns nullptr (it throws on a wrong-state call), so a null future is
+	// a library contract violation; fail-stop loudly instead of masking it as a fresh replay.
+	massert(recovery != nullptr, "recoverAsync returned a nullptr future");
+	// Bounded blocking wait: the network thread fail-stops on death, so recovery cannot
+	// hang forever, but it can still block the event loop for a backend timeout. Spin on
+	// isReady() so the stall is capped by the shared retry deadline; past it, give the op up.
+	while (!recovery->isReady()) {
+		if (std::chrono::steady_clock::now() >= deadline) {
+			safs::log_err(
+			    "matoclserv: backend recovery exceeded the sync retry deadline, giving up");
+			return {nullptr, true};
+		}
+		std::this_thread::sleep_for(std::chrono::milliseconds(1));
+	}
+	try {
+		recovery->get();
+		return {std::move(txn), false};
+	} catch (const kv::RetryableTransactionError &e) {
+		safs::log_info(
+		    "matoclserv: backend recovery failed (err {}), replaying on a fresh transaction: {}",
+		    e.errorCode(), e.what());
+		return {};
+	} catch (const kv::TransactionError &e) {
+		safs::log_err("matoclserv: backend recovery failed non-retryably (err {}): {}",
+		              e.errorCode(), e.what());
+		return {nullptr, true};
+	}
+}
+
+/// Body of the synchronous retry loop (matoclserv_commit_op_with_retry). Retryable body
+/// reads and retryable commit conflicts replay the whole body, bounded by gMaxCommitRetries
+/// and the wall-clock `deadline`: on the SAME transaction after backend recovery (whose
+/// bounded blocking wait IS the backend's pacing), or on a fresh transaction when recovery
+/// is unavailable or failed retryably, paced with the backend's jittered series
+/// (matoclserv_replay_delay, clamped to the deadline) so a persistent failure cannot burn
+/// the retry budget in a burst. A non-retryable recovery failure or a passed deadline fails
+/// the op. Non-OK body status returns without commit; non-retryable commit failure or retry
+/// exhaustion returns SAUNAFS_ERROR_IO. Unknown commit result is not replayed because it may
+/// have applied already; replay could double-apply. The body must rebuild out state each
+/// attempt and defer persistent in-memory side effects until OK. Without a read-write
+/// transaction, the body has already applied in place.
+static uint8_t matoclserv_commit_op_with_retry_impl(
+    const OpReplay &body, std::chrono::steady_clock::time_point deadline) {
+	std::unique_ptr<kv::IReadWriteTransaction> retained;
 	for (uint32_t attempt = 0;; ++attempt) {
-		FilesystemOperationContext ctx = gFSOperations->createFilesystemOperationContext(
-		    FilesystemOperationContext::TransactionType::kReadWrite);
-		if (ctx.hasReadWriteTransaction()) { ctx.setDeferChangelog(); }
-		uint8_t status;
+		// Refuse to START a new attempt past the budget: no fresh transaction, read, or
+		// commit may begin after the deadline. A call already in flight is bounded by the
+		// per-attempt transaction timeout set below, not by this check.
+		if (std::chrono::steady_clock::now() >= deadline) {
+			safs::log_warn("matoclserv: op retry deadline reached after {} attempts, giving up",
+			               attempt);
+			return SAUNAFS_ERROR_IO;
+		}
+		FilesystemOperationContext ctx =
+		    retained != nullptr ? FilesystemOperationContext(std::move(retained))
+		                        : gFSOperations->createFilesystemOperationContext(
+		                              FilesystemOperationContext::TransactionType::kReadWrite);
+		const bool hasTxn = ctx.hasReadWriteTransaction();
+		// Contain a kv::TransactionStateError (a coordinator SEQUENCING bug, e.g. a consumed
+		// future or a wrong-state call) ONLY here: pre-durability, on a rollback-capable
+		// transaction. Catching that narrow type, not std::logic_error, lets a genuine body
+		// bug (std::out_of_range, ...) still fail-stop instead of being masked as EIO. The
+		// durable-publication step and the no-transaction in-memory path deliberately sit
+		// OUTSIDE this try, so a bug there fail-stops rather than mask durable state as EIO.
 		try {
-			if (attempt < gDebugInjectReadConflicts) {
-				// Fault injection (no commit, no write): force the retry path.
-				throw kv::RetryableTransactionError(
-				    1031, "injected retryable read conflict (MATOCL_DEBUG_INJECT_READ_CONFLICTS)");
-			}
-			status = body(ctx);
-		} catch (const kv::RetryableTransactionError &e) {
-			if (attempt >= gMaxCommitRetries) {
-				safs::log_warn(
-				    "matoclserv: op body read retry exhausted after {} attempts (err {}): {}",
-				    attempt, e.errorCode(), e.what());
+			if (hasTxn) { ctx.setDeferChangelog(); }
+			uint8_t status;
+			try {
+				if (hasTxn) {
+					// Bound this attempt (reads and commit) to the remaining budget so a stuck
+					// backend cannot stall the event loop past the deadline; re-applied each
+					// attempt since a fresh replay restarts the clock. Kept inside this try so an
+					// option-set backend error fails the op with EIO, while a wrong-state throw
+					// still reaches the outer catch.
+					ctx.getReadWriteTransaction()->setTimeoutMs(matoclserv_remaining_ms(deadline));
+				}
+				if (attempt < gDebugInjectReadConflicts) {
+					// Fault injection (no commit, no write): force the retry path.
+					throw kv::RetryableTransactionError(
+					    1031,
+					    "injected retryable read conflict (MATOCL_DEBUG_INJECT_READ_CONFLICTS)");
+				}
+				status = body(ctx);
+			} catch (const kv::RetryableTransactionError &e) {
+				if (attempt >= gMaxCommitRetries || std::chrono::steady_clock::now() >= deadline) {
+					safs::log_warn(
+					    "matoclserv: op body read retry giving up after {} attempts (err {}): {}",
+					    attempt, e.errorCode(), e.what());
+					return SAUNAFS_ERROR_IO;
+				}
+				// An injected error never touched the transaction, so it has nothing to
+				// recover from; replay on a fresh one (as a real code path, not test-only:
+				// recovery below can also come back empty).
+				if (attempt >= gDebugInjectReadConflicts) {
+					auto recovered =
+					    matoclserv_recover_transaction_blocking(ctx, e.errorCode(), deadline);
+					if (recovered.giveUp) { return SAUNAFS_ERROR_IO; }
+					retained = std::move(recovered.txn);
+				}
+				// A recovered transaction was paced by the blocking recovery wait; a fresh
+				// replay paces itself with the backend's own series, clamped to the deadline.
+				if (retained == nullptr) {
+					matoclserv_sleep_bounded(matoclserv_replay_delay(attempt + 1), deadline);
+				}
+				safs::log_info(
+				    "matoclserv: retryable read error in op body (err {}), retrying, attempt {}",
+				    e.errorCode(), attempt + 1);
+				continue;
+			} catch (const kv::TransactionError &e) {
+				// Non-retryable backend failure: fail this op with EIO instead of letting
+				// the exception escape the event loop.
+				safs::log_err("matoclserv: backend transaction error in op body (err {}): {}",
+				              e.errorCode(), e.what());
 				return SAUNAFS_ERROR_IO;
 			}
-			safs::log_info(
-			    "matoclserv: retryable read error in op body (err {}), retrying, attempt {}",
-			    e.errorCode(), attempt + 1);
-			continue;
-		} catch (const kv::TransactionError &e) {
-			// Non-retryable backend failure: fail this op with EIO instead of letting
-			// the exception escape the event loop.
-			safs::log_err("matoclserv: backend transaction error in op body (err {}): {}",
-			              e.errorCode(), e.what());
+
+			if (status != SAUNAFS_STATUS_OK) { return status; }  // op error/status, do not commit
+			auto *txn = ctx.getReadWriteTransaction();
+			if (txn == nullptr) { return status; }  // in-memory Master: already applied in place
+
+			// Do not submit a commit we already know is past budget (the transaction is
+			// discarded unwritten; nothing durable).
+			if (std::chrono::steady_clock::now() >= deadline) {
+				safs::log_warn("matoclserv: op retry deadline reached before commit, giving up");
+				return SAUNAFS_ERROR_IO;
+			}
+			int commitError = 0;
+			bool retryable = false;
+			if (txn->commitAsync()->getResult(&commitError, &retryable)) {
+				// Durable: fall through (the sole normal exit of this try) to publish below,
+				// OUTSIDE the logic_error catch, so a post-durable throw fail-stops.
+			} else if (retryable && attempt < gMaxCommitRetries &&
+			           std::chrono::steady_clock::now() < deadline) {
+				auto recovered =
+				    matoclserv_recover_transaction_blocking(ctx, commitError, deadline);
+				if (recovered.giveUp) { return SAUNAFS_ERROR_IO; }
+				retained = std::move(recovered.txn);
+				if (retained == nullptr) {
+					matoclserv_sleep_bounded(matoclserv_replay_delay(attempt + 1), deadline);
+				}
+				safs::log_info(
+				    "matoclserv: sync commit conflict (err {}), replaying op, attempt {}",
+				    commitError, attempt + 1);
+				continue;
+			} else {
+				safs::log_err("matoclserv: sync commit failed (err {}, retryable {}), giving up",
+				              commitError, retryable);
+				return SAUNAFS_ERROR_IO;
+			}
+		} catch (const kv::TransactionStateError &e) {
+			// Rollback-capable and pre-durability: the transaction is destroyed with the
+			// context, leaving nothing durable, so contain the bug to this standalone op.
+			// Without a transaction there is no rollback (in-memory apply-in-place), so
+			// re-throw to fail-stop rather than pretend the op cleanly failed.
+			if (!hasTxn) { throw; }
+			safs::log_err(
+			    "matoclserv: coordinator invariant violated in sync op commit, failing op: {}",
+			    e.what());
 			return SAUNAFS_ERROR_IO;
 		}
 
-		if (status != SAUNAFS_STATUS_OK) { return status; }  // op error/status, do not commit
-		auto *txn = ctx.getReadWriteTransaction();
-		if (txn == nullptr) { return status; }  // in-memory Master: already applied in place
-
-		int commitError = 0;
-		bool retryable = false;
-		if (txn->commitAsync()->getResult(&commitError, &retryable)) {
-			matoclserv_commit_confirmed(ctx);
-			return SAUNAFS_STATUS_OK;  // durable
-		}
-		if (retryable && attempt < gMaxCommitRetries) {
-			safs::log_info(
-			    "matoclserv: sync commit conflict (err {}), replaying op, attempt {}",
-			    commitError, attempt + 1);
-			continue;
-		}
-		safs::log_err("matoclserv: sync commit failed (err {}, retryable {}), giving up", commitError,
-		              retryable);
-		return SAUNAFS_ERROR_IO;
+		// Reached only after a durable commit. Publication is POST-durability and is kept
+		// out of the catch above on purpose: a throw here (e.g. a changelog signal slot)
+		// must fail-stop, never be reported as EIO, because the KV mutation already landed
+		// and a caller retry would double-apply it.
+		matoclserv_commit_confirmed(ctx);
+		return SAUNAFS_STATUS_OK;  // durable
 	}
+}
+
+/// Runs a replayable op and commits synchronously, opening a fresh retry budget (see
+/// matoclserv_commit_op_with_retry_impl for the loop and its phase-aware TransactionStateError
+/// handling). Used by standalone post-durability cleanups outside the group batch because
+/// they can conflict with batched commits on the same inode. No exception is caught here:
+/// a catch would defeat the impl's phase boundary, which must let a coordinator
+/// TransactionStateError escape to fail-stop after a durable commit or on the transactionless
+/// in-memory path (masking it as EIO would hide durable or partial state), and must let a
+/// genuine caller logic bug (std::out_of_range, ...) escape everywhere.
+static uint8_t matoclserv_commit_op_with_retry(const OpReplay &body) {
+	const auto deadline = std::chrono::steady_clock::now() + kSyncRetryDeadline;
+	return matoclserv_commit_op_with_retry_impl(body, deadline);
 }
 
 // ---------------------------------------------------------------------------
@@ -455,6 +658,11 @@ struct OpBatch {
 	std::vector<BatchMember> members;
 	uint32_t attempt = 0;     ///< whole-batch commit attempts (conflict replays)
 	bool hasContext = false;  ///< ctx is created lazily for the open batch
+	/// True when this batch's commit future is a TEST-ONLY injected conflict (the real
+	/// transaction was never committed). Captured at launch: the injection setting is
+	/// reloadable, so re-deriving it at finalize time could misclassify the batch and
+	/// recover a transaction that is still Active.
+	bool injected = false;
 };
 
 static OpBatch gOpenBatch;
@@ -466,6 +674,35 @@ static std::deque<BatchMember> gHeldOps;
 // even in the window where gInFlightBatch is already reset, or its body would
 // run against state the resolution is still rebuilding.
 static bool gBatchResolving = false;
+
+/// A batch parked between commit attempts after a retryable conflict, in one of two
+/// flavors. Backend-recovery flavor: `txn` (the batch's own transaction, retained so
+/// the backend's accumulated backoff pacing survives across attempts) plus `recovery`,
+/// whose completion IS the backoff wait. Timed flavor (recovery unavailable: injected
+/// conflicts never touch the real transaction, or a recovery attempt failed): both
+/// null, replay on a fresh transaction once `notBefore` passes. The timed flavor has
+/// no dedicated timer: the replay starts on the first event-loop poll tick at or after
+/// `notBefore`, so the added latency is bounded by the poll cadence. While one is
+/// parked, arriving ops are held, keeping the invariant that bodies only ever run
+/// against durable state.
+struct BatchRetry {
+	std::vector<BatchMember> members;
+	uint32_t attempt = 0;  ///< the upcoming attempt number
+	/// Declared before `recovery` so the future is destroyed first.
+	std::unique_ptr<kv::IReadWriteTransaction> txn;
+	std::unique_ptr<kv::IVoidFuture> recovery;
+	std::chrono::steady_clock::time_point notBefore{};  ///< timed flavor only
+	std::chrono::steady_clock::time_point parkedAt{};   ///< recovery-flavor deadline base
+};
+static std::optional<BatchRetry> gBatchRetry;
+
+/// Upper bound on how long a recovery-flavor BatchRetry may stay parked. Backend
+/// recovery normally completes within the backoff cap (1s); a recovery future that is
+/// still not ready after this much longer means the backend client can no longer make
+/// progress (e.g. its network thread died), and waiting would also wedge shutdown:
+/// matoclserv_canexit blocks while a retry is parked, and matoclserv_term only runs
+/// after it. Past the deadline the batch fails with EIO and the retry is dropped.
+static constexpr std::chrono::seconds kBatchRecoveryDeadline{10};
 
 // Group-commit batch-stats accounting. Off by default; the master
 // flips it on with FDB_OP_PROFILING. Touched only on the single event-loop thread (the batch
@@ -631,9 +868,9 @@ static void matoclserv_submit_op(matoclserventry *eptr, OpReplay body,
                                  std::function<void(uint8_t status)> finish,
                                  std::function<void(uint8_t status)> onCommit = {}) {
 	eptr->pendingCommits++;
-	if (gInFlightBatch.has_value() || gBatchResolving) {
-		// Hold the body until the in-flight batch is durable so it runs against
-		// committed state (the soundness core of this design).
+	if (gInFlightBatch.has_value() || gBatchRetry.has_value() || gBatchResolving) {
+		// Hold the body until the in-flight batch (or its parked retry) is durable
+		// so it runs against committed state (the soundness core of this design).
 		if (gBatchStatsEnabled) { gBatchStats.heldOps++; }
 		gHeldOps.push_back(
 		    BatchMember{eptr, std::move(finish), std::move(body), 0, std::move(onCommit)});
@@ -660,8 +897,8 @@ static void matoclserv_poll_batch() {
 			future = ctx.getReadWriteTransaction()->commitAsync();
 		}
 		future->setReadyCallback(&matoclserv_commit_wakeup, nullptr);
-		gInFlightBatch.emplace(
-		    OpBatch{std::move(ctx), std::move(future), std::move(members), attempt, true});
+		gInFlightBatch.emplace(OpBatch{std::move(ctx), std::move(future), std::move(members),
+		                               attempt, true, attempt < gDebugInjectConflicts});
 	};
 
 	if (gInFlightBatch.has_value() && gInFlightBatch->future->isReady()) {
@@ -680,21 +917,40 @@ static void matoclserv_poll_batch() {
 			gInFlightBatch.reset();
 		} else if (retryable && gInFlightBatch->attempt < gMaxCommitRetries) {
 			// A conflict can only come from a writer outside the batch (sync
-			// handlers, chunkserver-driven writes, other masters): replay the whole
-			// batch on a fresh transaction and resubmit.
+			// handlers, chunkserver-driven writes, other masters): park the batch for
+			// a paced replay. Recover the SAME transaction when the failure came from
+			// a real commit; injected conflicts never touched it, so there is nothing
+			// to recover and they take the timed fresh-replay flavor.
 			if (gBatchStatsEnabled) { gBatchStats.batchReplays++; }
 			const uint32_t attempt = gInFlightBatch->attempt + 1;
 			safs::log_info(
 			    "matoclserv: batch commit conflict (err {}), replaying {} member(s), attempt {}",
 			    commitError, gInFlightBatch->members.size(), attempt);
-			std::vector<BatchMember> members = std::move(gInFlightBatch->members);
-			gInFlightBatch.reset();  // destroy the old future before its txn
-			FilesystemOperationContext ctx = matoclserv_replay_members(members);
-			// The replay may have replied and dropped every member; relaunch a commit only
-			// when some survived (this conflict path is KV only, so the ctx owns a txn).
-			if (!members.empty()) {
-				launchInFlightBatch(std::move(ctx), std::move(members), attempt);
+			BatchRetry retry;
+			retry.members = std::move(gInFlightBatch->members);
+			retry.attempt = attempt;
+			// The launch-time injected flag, NOT the reloadable setting: re-deriving it
+			// here could release a transaction the injected future never committed,
+			// still Active, and recoverAsync on it would fail stop the event loop.
+			if (!gInFlightBatch->injected) {
+				retry.txn = gInFlightBatch->ctx.releaseReadWriteTransaction();
 			}
+			gInFlightBatch.reset();  // destroy the consumed commit future
+			if (retry.txn != nullptr) {
+				retry.recovery = retry.txn->recoverAsync(commitError);
+				// Same contract as the sync path: a non-null txn yields a non-null future, so a
+				// null one is a library invariant violation, not a "no recovery available" case.
+				massert(retry.recovery != nullptr, "recoverAsync returned a nullptr future");
+			}
+			if (retry.recovery != nullptr) {
+				retry.recovery->setReadyCallback(&matoclserv_commit_wakeup, nullptr);
+				retry.parkedAt = std::chrono::steady_clock::now();
+			} else {
+				retry.txn.reset();
+				retry.notBefore =
+				    std::chrono::steady_clock::now() + matoclserv_replay_delay(attempt);
+			}
+			gBatchRetry.emplace(std::move(retry));
 		} else {
 			safs::log_err("matoclserv: batch commit failed (err {}, retryable {}), giving up",
 			              commitError, retryable);
@@ -705,11 +961,91 @@ static void matoclserv_poll_batch() {
 		}
 	}
 
+	// Resolve a parked retry: replay once its recovery completed (or its timer
+	// expired) and resubmit the batch. Replay-time finishes can submit follow-up
+	// ops, so this runs under gBatchResolving like the block above.
+	if (!gInFlightBatch.has_value() && gBatchRetry.has_value()) {
+		if (gBatchRetry->recovery != nullptr) {
+			if (gBatchRetry->recovery->isReady()) {
+				gBatchResolving = true;
+				BatchRetry retry = std::move(*gBatchRetry);
+				gBatchRetry.reset();
+				// Only backend failures are caught below. A std::logic_error (e.g. a
+				// consumed future) is a coordinator bug and fails stop, like everywhere
+				// else in the event loop.
+				try {
+					retry.recovery->get();
+					retry.recovery.reset();
+					// Replay onto the recovered transaction; if a member invalidates
+					// it, fall back to the fresh-transaction rebuild.
+					FilesystemOperationContext ctx(std::move(retry.txn));
+					ctx.setDeferChangelog();
+					bool restart = false;
+					for (size_t idx = 0; idx < retry.members.size() && !restart;) {
+						restart = matoclserv_replay_members_iteration(retry.members, idx, ctx);
+					}
+					if (restart) { ctx = matoclserv_replay_members(retry.members); }
+					// The replay may have replied and dropped every member; relaunch a
+					// commit only when some survived.
+					if (!retry.members.empty()) {
+						launchInFlightBatch(std::move(ctx), std::move(retry.members),
+						                    retry.attempt);
+					}
+				} catch (const kv::RetryableTransactionError &e) {
+					// The transaction is terminal after a failed recovery; fall back
+					// to a timed fresh replay.
+					safs::log_info(
+					    "matoclserv: batch recovery failed (err {}), timed fresh replay, "
+					    "attempt {}: {}",
+					    e.errorCode(), retry.attempt, e.what());
+					retry.recovery.reset();
+					retry.txn.reset();
+					retry.notBefore =
+					    std::chrono::steady_clock::now() + matoclserv_replay_delay(retry.attempt);
+					gBatchRetry.emplace(std::move(retry));
+				} catch (const kv::TransactionError &e) {
+					safs::log_err("matoclserv: batch recovery failed (err {}), giving up: {}",
+					              e.errorCode(), e.what());
+					for (BatchMember &member : retry.members) {
+						matoclserv_finish_member(member, SAUNAFS_ERROR_IO);
+					}
+				}
+			} else if (std::chrono::steady_clock::now() >=
+			           gBatchRetry->parkedAt + kBatchRecoveryDeadline) {
+				// Recovery normally resolves within the 1s backoff cap; well past that,
+				// the backend can no longer make progress and waiting longer would also
+				// wedge shutdown (canexit blocks while a retry is parked). Fail the
+				// members and drop the retry: the abandoned recovery future cancels
+				// itself and the unrecovered transaction is destroy-only.
+				gBatchResolving = true;
+				BatchRetry retry = std::move(*gBatchRetry);
+				gBatchRetry.reset();
+				safs::log_err(
+				    "matoclserv: batch recovery not ready after {}s, failing {} member(s)",
+				    std::chrono::duration_cast<std::chrono::seconds>(kBatchRecoveryDeadline)
+				        .count(),
+				    retry.members.size());
+				for (BatchMember &member : retry.members) {
+					matoclserv_finish_member(member, SAUNAFS_ERROR_IO);
+				}
+			}
+		} else if (std::chrono::steady_clock::now() >= gBatchRetry->notBefore) {
+			gBatchResolving = true;
+			BatchRetry retry = std::move(*gBatchRetry);
+			gBatchRetry.reset();
+			FilesystemOperationContext ctx = matoclserv_replay_members(retry.members);
+			if (!retry.members.empty()) {
+				launchInFlightBatch(std::move(ctx), std::move(retry.members), retry.attempt);
+			}
+		}
+	}
+
 	gBatchResolving = false;
 
-	// Drain held ops into the open batch once nothing is in flight. Bodies run
-	// here, against the now-durable state. FIFO keeps per-connection op order.
-	while (!gInFlightBatch.has_value() && !gHeldOps.empty()) {
+	// Drain held ops into the open batch once neither a batch nor a parked retry is
+	// pending. Bodies run here, against the now-durable state. FIFO keeps
+	// per-connection op order.
+	while (!gInFlightBatch.has_value() && !gBatchRetry.has_value() && !gHeldOps.empty()) {
 		BatchMember held = std::move(gHeldOps.front());
 		gHeldOps.pop_front();
 		if (held.eptr->mode == ClientConnectionMode::KILL) {
@@ -719,8 +1055,9 @@ static void matoclserv_poll_batch() {
 		matoclserv_join_open_batch(std::move(held));
 	}
 
-	// Submit the open batch.
-	if (!gInFlightBatch.has_value() && !gOpenBatch.members.empty()) {
+	// Submit the open batch. The retry gate is defensive: while a retry is parked,
+	// submits are held, so the open batch stays empty.
+	if (!gInFlightBatch.has_value() && !gBatchRetry.has_value() && !gOpenBatch.members.empty()) {
 		launchInFlightBatch(std::move(gOpenBatch.ctx), std::move(gOpenBatch.members), 0);
 		gOpenBatch.members.clear();
 		gOpenBatch.hasContext = false;
@@ -6828,6 +7165,7 @@ void matoclserv_term() {
 	// Drop any in-flight batch commits before tearing down client entries so their
 	// reply continuations (which capture eptr) cannot run against freed memory.
 	gInFlightBatch.reset();
+	gBatchRetry.reset();
 	gHeldOps.clear();
 	gOpenBatch.members.clear();
 	gOpenBatch.hasContext = false;
@@ -6998,9 +7336,11 @@ int matoclserv_canexit() {
 		return 0;
 	}
 
-	// Wait for the group-commit pipeline to drain: an in-flight batch's continuations
-	// still reference client entries, and held ops have unsent replies.
-	if (gInFlightBatch.has_value() || !gHeldOps.empty() || !gOpenBatch.members.empty()) {
+	// Wait for the group-commit pipeline to drain: an in-flight batch's (or parked
+	// retry's) continuations still reference client entries, and held ops have
+	// unsent replies.
+	if (gInFlightBatch.has_value() || gBatchRetry.has_value() || !gHeldOps.empty() ||
+	    !gOpenBatch.members.empty()) {
 		return 0;
 	}
 
@@ -7251,6 +7591,7 @@ void matoclserv_reload() {
 	gMaxCommitRetries = cfg_getuint32("MATOCL_MAX_COMMIT_RETRIES", 5U);
 	gDebugInjectConflicts = cfg_getuint32("MATOCL_DEBUG_INJECT_COMMIT_CONFLICTS", 0U);
 	gDebugInjectReadConflicts = cfg_getuint32("MATOCL_DEBUG_INJECT_READ_CONFLICTS", 0U);
+	gDebugInjectRecoveryErrors = cfg_getuint32("MATOCL_DEBUG_INJECT_RECOVERY_ERRORS", 0U);
 
 	std::string oldListenHost = gListenHost;
 	std::string oldListenPort = gListenPort;
@@ -7304,6 +7645,7 @@ int matoclserv_network_init() {
 	gMaxCommitRetries = cfg_getuint32("MATOCL_MAX_COMMIT_RETRIES", 5U);
 	gDebugInjectConflicts = cfg_getuint32("MATOCL_DEBUG_INJECT_COMMIT_CONFLICTS", 0U);
 	gDebugInjectReadConflicts = cfg_getuint32("MATOCL_DEBUG_INJECT_READ_CONFLICTS", 0U);
+	gDebugInjectRecoveryErrors = cfg_getuint32("MATOCL_DEBUG_INJECT_RECOVERY_ERRORS", 0U);
 
 	if (matoclserv_iolimits_reload() != 0) {
 		return -1;


### PR DESCRIPTION
Hardens the FoundationDB client wrapper and the master's transaction-retry
architecture. The retry coordinator reuses the same transaction across
attempts, driven by fdb_transaction_on_error, so the backend's
accumulating backoff is preserved rather than reset on every attempt.
This mirrors the retry loops of the official FoundationDB clients (Java
Database.run, Python @fdb.transactional, Go Transact).

Where it deliberately diverges is the maybe-committed outcome. The
official transactional retry loops treat commit_unknown_result as
retryable and leave idempotency to the caller, so a non-idempotent
transaction can be applied twice. The master's operations are not yet
idempotent, so the wrapper instead moves a maybe-committed transaction
into a destroy-only state and never replays it, trading availability for
the guarantee that a commit is never applied twice. An explicit
per-transaction state machine and a process-wide client runtime make that
boundary enforceable.

Related to: LS-962