### PR TITLE
refactor(master): hook metadataserver queries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,7 +73,7 @@ if(ENABLE_CCACHE AND CCACHE_FOUND)
   message(STATUS "Using ccache")
 endif()
 
-set(DEFAULT_MIN_VERSION "5.11.0")
+set(DEFAULT_MIN_VERSION "5.12.0")
 
 include(GNUInstallDirs)
 

--- a/src/admin/list_metadataservers_command.cc
+++ b/src/admin/list_metadataservers_command.cc
@@ -92,17 +92,31 @@ void ListMetadataserversCommand::run(const Options& options) const {
 	std::reverse(shadowsList.begin(), shadowsList.end());
 	int server = 1;
 	for (const auto& e : shadowsList) {
-		MetadataserverStatus s{"unknown", "unknown", 0};
+		MetadataserverStatus s{"unknown", "unknown", 0, std::nullopt};
 		std::string hostname;
 		// If information about MATOCL_SERV_PORT used by shadows isn't available we cannot query it
 		// for its hostname, metaversion etc.
 		if (e.port != 0) {
-			ServerConnection shadowConnection(NetworkAddress(e.ip, e.port), tlsCfg);
-			s = MetadataserverStatusCommand::getStatus(shadowConnection);
+			bool statusKnown = false;
+			try {
+				ServerConnection shadowConnection(NetworkAddress(e.ip, e.port), tlsCfg);
+				// The list reply already carries each member's software version, so the
+				// status query can be built in the right shape without probing the member.
+				s = MetadataserverStatusCommand::getStatus(ipToString(e.ip), std::to_string(e.port),
+				                                           tlsCfg, e.version);
+				statusKnown = true;
 
-			auto request = cltoma::hostname::build();
-			auto response = shadowConnection.sendAndReceive(request, SAU_MATOCL_HOSTNAME);
-			matocl::hostname::deserialize(response, hostname);
+				auto request = cltoma::hostname::build();
+				auto response = shadowConnection.sendAndReceive(request, SAU_MATOCL_HOSTNAME);
+				matocl::hostname::deserialize(response, hostname);
+			} catch (const std::exception &) {
+				// One unreachable member must not hide the rest of the list, and a failed
+				// hostname lookup alone must not discard a status already fetched.
+				if (!statusKnown) {
+					s = MetadataserverStatus{"unreachable", "unreachable", 0, std::nullopt};
+				}
+				hostname = "unreachable";
+			}
 		} else {
 			hostname = "unknown";
 		}

--- a/src/admin/metadataserver_status_command.cc
+++ b/src/admin/metadataserver_status_command.cc
@@ -24,6 +24,8 @@
 #include <iomanip>
 #include <iostream>
 
+#include "common/saunafs_version.h"
+#include "common/server_connection.h"
 #include "protocol/cltoma.h"
 #include "protocol/matocl.h"
 
@@ -48,28 +50,65 @@ void MetadataserverStatusCommand::run(const Options& options) const {
 	auto tlsCfg =
 	    options.getValue<std::string>("--tlsconfigfile", std::string(TlsSession::kNoFile));
 
-	ServerConnection connection(options.argument(0), options.argument(1), tlsCfg);
-	MetadataserverStatus s = MetadataserverStatusCommand::getStatus(connection);
+	MetadataserverStatus s =
+	    MetadataserverStatusCommand::getStatus(options.argument(0), options.argument(1), tlsCfg);
 
 	if (options.isSet(kPorcelainMode)) {
-		std::cout << s.personality << "\t" << s.serverStatus << "\t"
-				<< s.metadataVersion << std::endl;
+		std::cout << s.personality << "\t" << s.serverStatus << "\t" << s.metadataVersion;
+		// Only Master/Shadow's existing 3-field porcelain output must stay byte-for-byte
+		// unchanged; the 4th field is appended only when there is an mdsId to report.
+		if (s.mdsId) { std::cout << "\t" << *s.mdsId; }
+		std::cout << std::endl;
 	} else {
 		std::cout << "     personality: " << s.personality << std::endl;
 		std::cout << "   server status: " << s.serverStatus << std::endl;
 		std::cout << "metadata version: " << s.metadataVersion << std::endl;
+		if (s.mdsId) { std::cout << "          mds id: " << *s.mdsId << std::endl; }
 	}
 }
 
-MetadataserverStatus MetadataserverStatusCommand::getStatus(ServerConnection& connection) {
-	std::vector<uint8_t> request;
-	request = cltoma::metadataserverStatus::build(1);
-	auto response = connection.sendAndReceive(request, SAU_MATOCL_METADATASERVER_STATUS);
+MetadataserverStatus MetadataserverStatusCommand::getStatus(
+    const std::string &host, const std::string &port, const std::string &tlsConfigFile,
+    std::optional<uint32_t> knownPeerVersion) {
+	auto sendStatusRequest = [&](bool wantsIdentity) {
+		MessageBuffer request;
+		if (wantsIdentity) {
+			request = cltoma::metadataserverStatus::build(1, uint8_t{1});
+		} else {
+			request = cltoma::metadataserverStatus::build(1);
+		}
+		ServerConnection connection(host, port, tlsConfigFile);
+		return connection.sendAndReceive(request, SAU_MATOCL_METADATASERVER_STATUS);
+	};
+
+	MessageBuffer response;
+	if (knownPeerVersion) {
+		response = sendStatusRequest(*knownPeerVersion >= kFirstVersionWithMdsRegistry);
+	} else {
+		// Prefer the identity-bearing request when the peer version is unknown. Releases
+		// older than 5.12 reject that packet shape and close the connection, so retry the
+		// legacy request on a fresh connection. Response decoding stays outside this catch:
+		// a malformed response is not evidence that the peer needs the legacy request.
+		try {
+			response = sendStatusRequest(true);
+		} catch (const std::exception &) { response = sendStatusRequest(false); }
+	}
+
+	PacketVersion packetVersion;
+	deserializePacketVersionNoHeader(response, packetVersion);
 
 	uint32_t messageId;
 	uint8_t status;
 	uint64_t metadataVersion;
-	matocl::metadataserverStatus::deserialize(response, messageId, status, metadataVersion);
+	std::optional<uint32_t> mdsId;
+	if (packetVersion == matocl::metadataserverStatus::kWithIdentityResponse) {
+		uint32_t reportedMdsId;
+		matocl::metadataserverStatus::deserialize(response, messageId, status, metadataVersion,
+		                                          reportedMdsId);
+		mdsId = reportedMdsId;
+	} else {
+		matocl::metadataserverStatus::deserialize(response, messageId, status, metadataVersion);
+	}
 
 	std::string personality, serverStatus;
 	switch (status) {
@@ -89,5 +128,5 @@ MetadataserverStatus MetadataserverStatusCommand::getStatus(ServerConnection& co
 		personality = "<unknown>";
 		serverStatus = "<unknown>";
 	}
-	return MetadataserverStatus{personality, serverStatus, metadataVersion};
+	return MetadataserverStatus{personality, serverStatus, metadataVersion, mdsId};
 }

--- a/src/admin/metadataserver_status_command.h
+++ b/src/admin/metadataserver_status_command.h
@@ -22,13 +22,16 @@
 
 #include "common/platform.h"
 
-#include "common/server_connection.h"
+#include <cstdint>
+#include <optional>
+
 #include "admin/saunafs_admin_command.h"
 
 struct MetadataserverStatus {
 	std::string personality;
 	std::string serverStatus;
 	uint64_t metadataVersion;
+	std::optional<uint32_t> mdsId;
 };
 
 class MetadataserverStatusCommand : public SaunaFsAdminCommand {
@@ -37,5 +40,11 @@ public:
 	void usage() const override;
 	SupportedOptions supportedOptions() const override;
 	void run(const Options& options) const override;
-	static MetadataserverStatus getStatus(ServerConnection& connection);
+	/// Queries host:port for its status. When the caller already knows the peer's software
+	/// version (e.g. from a metadataservers list reply, which carries one per member),
+	/// passing it picks the request shape directly; otherwise the identity-bearing request is
+	/// tried first, with the legacy request retried on a fresh connection if the peer rejects it.
+	static MetadataserverStatus getStatus(const std::string &host, const std::string &port,
+	                                      const std::string &tlsConfigFile,
+	                                      std::optional<uint32_t> knownPeerVersion = std::nullopt);
 };

--- a/src/common/saunafs_version.h
+++ b/src/common/saunafs_version.h
@@ -57,3 +57,4 @@ constexpr uint32_t kFirstVersionWithUnlockChunkNotice = saunafsVersion(5, 8, 0);
 constexpr uint32_t kFirstVersionWithChunkserverSideChunkLock = saunafsVersion(5, 8, 0);
 constexpr uint32_t kFirstVersionWithWriteFlushPacket = saunafsVersion(5, 11, 0);
 constexpr uint32_t kFirstVersionWithFusedCreate = saunafsVersion(5, 11, 0);
+constexpr uint32_t kFirstVersionWithMdsRegistry = saunafsVersion(5, 12, 0);

--- a/src/master/kv_common_keys.h
+++ b/src/master/kv_common_keys.h
@@ -65,6 +65,23 @@ inline constexpr std::string_view kSessionRangeStartKey = "META_NEXT_SESSION_RAN
 /// has ever been allocated"; allocated ids start at 1.
 inline constexpr std::string_view kMetaNextMdsIdKey = "META_NEXT_MDS_ID";
 
+/// Prefix for per-MDS cluster membership records.
+/// Format: MDS_REGISTRY_<MdsId (Big Endian)> : <Ip><MatoclPort><MatocsPort><Version>
+/// Written once by the owning MDS at startup; no other process ever writes this row.
+/// @note Deliberately separate from MDS_HEARTBEAT_ (below): this row never changes while
+/// its process lives, while the heartbeat renews constantly, so splitting them keeps
+/// renewal conflict-free.
+inline constexpr std::string_view kMdsRegistryKeyPrefix = "MDS_REGISTRY_";
+
+/// Prefix for per-MDS liveness signals.
+/// Format: MDS_HEARTBEAT_<MdsId (Big Endian)> : <UnixTimestamp, uint64_t Little Endian>
+/// Renewed by the owning MDS on its periodic tick with a plain blind set: the row has a
+/// single writer, so nothing needs atomicMax ordering, and a renewal after a forward
+/// clock step heals an implausibly-future value within one tick instead of pinning it
+/// until wall time catches up. No ownership or takeover semantics: every MDS only ever
+/// touches its own row.
+inline constexpr std::string_view kMdsHeartbeatKeyPrefix = "MDS_HEARTBEAT_";
+
 // Keys for filesystem statistics
 inline constexpr std::string_view kMetaNodesKey = "META_NODES";
 inline constexpr std::string_view kMetaTrashSpaceKey = "META_TRASH_SPACE";

--- a/src/master/matoclserv.cc
+++ b/src/master/matoclserv.cc
@@ -104,6 +104,7 @@
 #include "master/matontserv.h"
 #include "master/metadata_backend_common.h"
 #include "master/metadata_backend_interface.h"
+#include "master/metadataserver_hooks.h"
 #include "master/personality.h"
 #include "master/settrashtime_task.h"
 #include "metrics/metrics.h"
@@ -1150,6 +1151,16 @@ static int starting;  ///< Flag indicating whether the server is starting (1) or
 static std::string gListenHost;
 static std::string gListenPort;
 
+uint16_t matoclserv_get_listen_port() {
+	// Resolved through the same getaddrinfo path the listener bound with, so a service name
+	// (e.g. from /etc/services) reports the port it actually resolved to at bind time.
+	uint16_t port = 0;
+	if (tcpresolve(nullptr, gListenPort.c_str(), nullptr, &port, 1) < 0) { return 0; }
+	return port;
+}
+
+const std::string &matoclserv_get_listen_host() { return gListenHost; }
+
 static uint32_t gIoLimitsAccumulate_ms;
 static double gIoLimitsRefreshTime;
 static uint32_t gIoLimitsConfigId;
@@ -1784,21 +1795,45 @@ void matoclserv_iolimits_status(matoclserventry* eptr, const uint8_t* data, uint
 /// @param length The length of the data received
 void matoclserv_metadataserver_status(matoclserventry* eptr, const uint8_t* data, uint32_t length) {
 	uint32_t messageId = 0;
-	cltoma::metadataserverStatus::deserialize(data, length, messageId);
+	uint8_t requestsIdentity = 0;
+	PacketVersion packetVersion;
+	deserializePacketVersionNoHeader(data, length, packetVersion);
+	if (packetVersion == cltoma::metadataserverStatus::kWithIdentityRequest) {
+		cltoma::metadataserverStatus::deserialize(data, length, messageId, requestsIdentity);
+	} else {
+		cltoma::metadataserverStatus::deserialize(data, length, messageId);
+	}
 
 	uint64_t metadataVersion = 0;
 	try {
 		metadataVersion = gFSOperations->getMetadataVersion();
 	} catch (NoMetadataException &) {}
 
-	uint8_t status =
-	    metadataserver::isMaster()
-	        ? SAU_METADATASERVER_STATUS_MASTER
-	        : (masterconn_is_connected() ? SAU_METADATASERVER_STATUS_SHADOW_CONNECTED
-	                                     : SAU_METADATASERVER_STATUS_SHADOW_DISCONNECTED);
+	MetadataserverStatusResult result;
+	try {
+		result = gMetadataserverStatusHook();
+	} catch (const std::exception &exception) {
+		// Same contract as matoclserv_metadataservers_list: a failing hook drops only this
+		// connection, never the process.
+		safs::log_err("main master server module: metadataserver status failed: {}",
+		              exception.what());
+		eptr->mode = ClientConnectionMode::KILL;
+		return;
+	} catch (...) {
+		safs::log_err("main master server module: metadataserver status failed");
+		eptr->mode = ClientConnectionMode::KILL;
+		return;
+	}
 
 	MessageBuffer buffer;
-	matocl::metadataserverStatus::serialize(buffer, messageId, status, metadataVersion);
+	// Fall back to the legacy shape if the hook has no identity to report (e.g.
+	// leil-master's default hook), even when the client asked for the richer one.
+	if (packetVersion == cltoma::metadataserverStatus::kWithIdentityRequest && result.identity) {
+		matocl::metadataserverStatus::serialize(buffer, messageId, result.status, metadataVersion,
+		                                        result.identity->mdsId);
+	} else {
+		matocl::metadataserverStatus::serialize(buffer, messageId, result.status, metadataVersion);
+	}
 	matoclserv_createpacket(eptr, std::move(buffer));
 }
 
@@ -2215,8 +2250,25 @@ void matoclserv_inotifier_list(matoclserventry *eptr, const uint8_t *data, uint3
 
 void matoclserv_metadataservers_list(matoclserventry* eptr, const uint8_t* data, uint32_t length) {
 	cltoma::metadataserversList::deserialize(data, length);
-	matoclserv_createpacket(eptr, matocl::metadataserversList::build(SAUNAFS_VERSHEX,
-			matomlserv_shadows()));
+
+	std::vector<MetadataserverListEntry> entries;
+	try {
+		entries = gMetadataserversListHook();
+	} catch (const std::exception &exception) {
+		// The hook's implementation may live outside this module (a KV-backed registry) and
+		// can fail or refuse. Drop only this connection, so the caller sees a failed query
+		// rather than an answer indistinguishable from an empty cluster, and an exception
+		// type from outside the backend error family cannot fail-stop the whole process.
+		safs::log_err("main master server module: metadataservers list failed: {}",
+		              exception.what());
+		eptr->mode = ClientConnectionMode::KILL;
+		return;
+	} catch (...) {
+		safs::log_err("main master server module: metadataservers list failed");
+		eptr->mode = ClientConnectionMode::KILL;
+		return;
+	}
+	matoclserv_createpacket(eptr, matocl::metadataserversList::build(SAUNAFS_VERSHEX, entries));
 }
 
 static void matoclserv_send_iolimits_cfg(matoclserventry *eptr) {

--- a/src/master/matoclserv.h
+++ b/src/master/matoclserv.h
@@ -24,6 +24,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <string>
 
 #include "common/type_defs.h"
 
@@ -99,6 +100,19 @@ void matoclserv_set_batch_stats_enabled(bool enabled);
 
 /// Returns the current group-commit batch-stats counters (process-wide, since process start).
 MatoclBatchStats matoclserv_get_batch_stats();
+
+/// Returns the port this instance is actually listening on for client/admin connections,
+/// resolved the same way the listener resolved it at bind time (a number or a service
+/// name); 0 means no concrete port (the ephemeral "*", or a string naming no port).
+/// Can differ from MATOCL_LISTEN_PORT's raw config value right after a reload that failed
+/// to rebind: the listener then keeps its previous, working port, but config already shows
+/// the new one.
+uint16_t matoclserv_get_listen_port();
+
+/// Returns the host this instance is actually bound to for client/admin connections. Can
+/// differ from MATOCL_LISTEN_HOST's raw config value the same way matoclserv_get_listen_port
+/// can differ from its own config value.
+const std::string &matoclserv_get_listen_host();
 
 /// Requests one quiescent group-commit window for background metadata maintenance.
 /// Already staged client work is committed first; newly submitted bodies remain held

--- a/src/master/matocsserv.cc
+++ b/src/master/matocsserv.cc
@@ -544,6 +544,14 @@ void matocsserv_getspace(uint64_t *totalspace,uint64_t *availspace) {
 	*availspace = tspace-uspace;
 }
 
+uint16_t matocsserv_get_listen_port() {
+	// Resolved through the same getaddrinfo path the listener bound with, so a service name
+	// (e.g. from /etc/services) reports the port it actually resolved to at bind time.
+	uint16_t port = 0;
+	if (tcpresolve(nullptr, gListenPort.c_str(), nullptr, &port, 1) < 0) { return 0; }
+	return port;
+}
+
 const char* matocsserv_getstrip(matocsserventry *eptr) {
 	static const char *empty = "???";
 	if (eptr->mode != ChunkserverConnectionMode::KILL && !eptr->serviceStrIp.empty()) {

--- a/src/master/matocsserv.h
+++ b/src/master/matocsserv.h
@@ -123,6 +123,13 @@ void matocsserv_sorted_servers_refresh_done();
 std::vector<std::pair<matocsserventry *, ChunkPartType>> matocsserv_getservers_for_new_chunk(
     uint8_t goalId, uint16_t &min_server_count, uint32_t min_server_version = 0);
 void matocsserv_getspace(uint64_t* totalspace, uint64_t* availspace);
+/// Returns the port this instance is actually listening on for chunkserver connections,
+/// resolved the same way the listener resolved it at bind time (a number or a service
+/// name); 0 means no concrete port (the ephemeral "*", or a string naming no port).
+/// Can differ from MATOCS_LISTEN_PORT's raw config value right after a reload that failed
+/// to rebind: the listener then keeps its previous, working port, but config already shows
+/// the new one.
+uint16_t matocsserv_get_listen_port();
 const char* matocsserv_getstrip(matocsserventry* eptr);
 uint32_t matocsserv_get_servip(matocsserventry *eptr);
 int matocsserv_getlocation(matocsserventry* eptr, uint32_t* servip, uint16_t* servport,

--- a/src/master/metadataserver_hooks.cc
+++ b/src/master/metadataserver_hooks.cc
@@ -1,0 +1,45 @@
+/*
+   Copyright 2026      Leil Storage OÜ
+
+   This file is part of SaunaFS.
+
+   SaunaFS is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, version 3.
+
+   SaunaFS is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with SaunaFS. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "common/platform.h"
+
+#include "master/metadataserver_hooks.h"
+
+#include "master/masterconn.h"
+#include "master/matomlserv.h"
+#include "master/personality.h"
+#include "protocol/SFSCommunication.h"
+
+namespace {
+
+MetadataserverStatusResult defaultMetadataserverStatus() {
+	MetadataserverStatusResult result;
+	result.status =
+	    metadataserver::isMaster()
+	        ? SAU_METADATASERVER_STATUS_MASTER
+	        : (masterconn_is_connected() ? SAU_METADATASERVER_STATUS_SHADOW_CONNECTED
+	                                     : SAU_METADATASERVER_STATUS_SHADOW_DISCONNECTED);
+	return result;
+}
+
+std::vector<MetadataserverListEntry> defaultMetadataserversList() { return matomlserv_shadows(); }
+
+}  // namespace
+
+MetadataserversListHook gMetadataserversListHook = defaultMetadataserversList;
+MetadataserverStatusHook gMetadataserverStatusHook = defaultMetadataserverStatus;

--- a/src/master/metadataserver_hooks.h
+++ b/src/master/metadataserver_hooks.h
@@ -1,0 +1,59 @@
+/*
+   Copyright 2026      Leil Storage OÜ
+
+   This file is part of SaunaFS.
+
+   SaunaFS is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, version 3.
+
+   SaunaFS is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with SaunaFS. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include "common/platform.h"
+
+#include <cstdint>
+#include <functional>
+#include <optional>
+#include <vector>
+
+#include "common/metadataserver_list_entry.h"
+
+/// Returns the list of other known metadata servers. Defaults to today's Master/Shadow
+/// logic (matomlserv_shadows), a leil-mds reassigns this at startup to read its
+/// FoundationDB-backed cluster registry instead. A plain hook, not a virtual interface,
+/// since this is one stateless, read-only query with no state spanning calls.
+/// May throw when the underlying read fails or refuses (e.g. an unreachable backend, or a
+/// scan that would exceed its row cap): the dispatch site translates any exception into
+/// dropping that one admin connection, so the caller sees a failed query, never a result
+/// indistinguishable from an empty cluster.
+using MetadataserversListHook = std::function<std::vector<MetadataserverListEntry>()>;
+extern MetadataserversListHook gMetadataserversListHook;
+
+/// Per-instance identity a metadataserver-status reply carries only when the requester
+/// understands the newer packet version. Populated only by the KV-mode hook.
+struct MetadataserverIdentity {
+	uint32_t mdsId = 0;
+};
+
+/// This instance's status (SAU_METADATASERVER_STATUS_MASTER/SHADOW_*) and, when known,
+/// its identity.
+struct MetadataserverStatusResult {
+	uint8_t status = 0;
+	std::optional<MetadataserverIdentity> identity;
+};
+
+/// Returns this instance's status. Defaults to today's Master/Shadow logic
+/// (isMaster/masterconn_is_connected), identity left empty, a leil-mds reassigns this at
+/// startup to also report its mds_id. Same failure contract as gMetadataserversListHook:
+/// an implementation may throw, and the dispatch site drops that one connection.
+using MetadataserverStatusHook = std::function<MetadataserverStatusResult()>;
+extern MetadataserverStatusHook gMetadataserverStatusHook;

--- a/src/protocol/cltoma.h
+++ b/src/protocol/cltoma.h
@@ -164,9 +164,17 @@ SAUNAFS_DEFINE_PACKET_SERIALIZATION(
 		uint32_t, messageId)
 
 // SAU_CLTOMA_METADATASERVER_STATUS
+SAUNAFS_DEFINE_PACKET_VERSION(cltoma, metadataserverStatus, kLegacyRequest, 0)
+SAUNAFS_DEFINE_PACKET_VERSION(cltoma, metadataserverStatus, kWithIdentityRequest, 1)
 SAUNAFS_DEFINE_PACKET_SERIALIZATION(
-		cltoma, metadataserverStatus, SAU_CLTOMA_METADATASERVER_STATUS, 0,
+		cltoma, metadataserverStatus, SAU_CLTOMA_METADATASERVER_STATUS, kLegacyRequest,
 		uint32_t, messageId)
+// requestsIdentity only needs to exist so this version's build/deserialize overload has a
+// different arity from kLegacyRequest's; the version tag itself is already the real signal.
+SAUNAFS_DEFINE_PACKET_SERIALIZATION(
+		cltoma, metadataserverStatus, SAU_CLTOMA_METADATASERVER_STATUS, kWithIdentityRequest,
+		uint32_t, messageId,
+		uint8_t, requestsIdentity)
 
 // SAU_CLTOMA_METADATASERVERS_LIST
 SAUNAFS_DEFINE_PACKET_SERIALIZATION(

--- a/src/protocol/matocl.h
+++ b/src/protocol/matocl.h
@@ -191,11 +191,19 @@ SAUNAFS_DEFINE_PACKET_SERIALIZATION(
 		std::vector<IoGroupAndLimit>, groupsAndLimits)
 
 // SAU_MATOCL_METADATASERVER_STATUS
+SAUNAFS_DEFINE_PACKET_VERSION(matocl, metadataserverStatus, kLegacyResponse, 0)
+SAUNAFS_DEFINE_PACKET_VERSION(matocl, metadataserverStatus, kWithIdentityResponse, 1)
 SAUNAFS_DEFINE_PACKET_SERIALIZATION(
-		matocl, metadataserverStatus, SAU_MATOCL_METADATASERVER_STATUS, 0,
+		matocl, metadataserverStatus, SAU_MATOCL_METADATASERVER_STATUS, kLegacyResponse,
 		uint32_t, messageId,
 		uint8_t, status,
 		uint64_t, metadataVersion)
+SAUNAFS_DEFINE_PACKET_SERIALIZATION(
+		matocl, metadataserverStatus, SAU_MATOCL_METADATASERVER_STATUS, kWithIdentityResponse,
+		uint32_t, messageId,
+		uint8_t, status,
+		uint64_t, metadataVersion,
+		uint32_t, mdsId)
 
 // SAU_MATOCL_FUSE_GETGOAL
 SAUNAFS_DEFINE_PACKET_VERSION(matocl, fuseGetGoal, kStatusPacketVersion, 0)

--- a/tests/test_suites/ShortSystemTests/test_upgrade_admin_metadataservers.sh
+++ b/tests/test_suites/ShortSystemTests/test_upgrade_admin_metadataservers.sh
@@ -1,0 +1,70 @@
+timeout_set 5 minutes
+
+# Both admin commands must stay compatible across a version boundary, in both directions:
+# the current admin against the newest released master (which rejects the identity-bearing
+# status request and kills that connection), and that release's own admin against a current
+# master (which must keep answering the original packet shapes unchanged).
+legacy_version="5.11.0"
+
+CHUNKSERVERS=0 \
+	MASTERSERVERS=2 \
+	USE_RAMDISK=YES \
+	START_WITH_LEGACY_SAUNAFS=YES \
+	SAUNAFSXX_TAG="${legacy_version}" \
+	SAUNAFSXX_TAG_APT="${legacy_version}-1" \
+	setup_local_empty_saunafs info
+
+# Explicit path, so every phase below is unambiguous about which admin binary it runs
+# (the released one is always reached through saunafs_old_admin_master).
+new_admin="${SAUNAFS_ROOT}/bin/saunafs-admin"
+
+# Baseline: the cluster really runs the released version at this point. The version
+# switch proven below would be vacuous if the build under test WERE the legacy release.
+assert_success test "${SAUNAFS_VERSION}" != "${legacy_version}"
+assert_equals 1 $(saunafs_admin_master info | grep "^SaunaFS v${legacy_version//./\\.}$" | wc -l)
+
+# Current admin against the released master: the identity-bearing request is rejected there
+# (that connection gets killed), so a correct answer proves the fresh-connection fallback
+# to the original request shape works against a real released binary.
+statusOldMaster=$("${new_admin}" metadataserver-status --porcelain localhost "${info[matocl]}")
+assert_equals $'master\trunning' "$(echo "${statusOldMaster}" | cut -f1-2)"
+assert_equals 3 "$(echo "${statusOldMaster}" | awk -F'\t' '{print NF}')"
+
+# With a released shadow up, the list command's per-member follow-up must pick the
+# original status shape from the member's own advertised version, with no extra query or fallback.
+saunafsXX_shadow_daemon_n 1 start
+assert_eventually "saunafs_shadow_synchronized 1"
+
+listOldMaster=$("${new_admin}" list-metadataservers --porcelain localhost "${info[matocl]}")
+assert_equals 2 "$(echo "${listOldMaster}" | wc -l)"
+assert_awk_finds '/ master running /' "${listOldMaster}"
+assert_awk_finds '/ shadow connected /' "${listOldMaster}"
+assert_awk_finds "/${legacy_version//./\\.}/" "${listOldMaster}"
+
+# Upgrade master and shadow in place to the current build, and prove the switch really
+# happened before asserting anything against "the new master".
+saunafs_master_daemon restart
+saunafs_master_n 1 restart
+assert_eventually "saunafs_shadow_synchronized 1"
+assert_equals 1 $(saunafs_admin_master info | grep "^SaunaFS v${SAUNAFS_VERSION//./\\.}$" | wc -l)
+
+# The released admin against the current master and shadow: both commands must keep
+# answering in the original shapes, unchanged.
+statusOldAdmin=$(saunafs_old_admin_master metadataserver-status --porcelain)
+assert_equals $'master\trunning' "$(echo "${statusOldAdmin}" | cut -f1-2)"
+assert_equals 3 "$(echo "${statusOldAdmin}" | awk -F'\t' '{print NF}')"
+
+listOldAdmin=$(saunafs_old_admin_master list-metadataservers --porcelain)
+assert_equals 2 "$(echo "${listOldAdmin}" | wc -l)"
+assert_awk_finds '/ master running /' "${listOldAdmin}"
+assert_awk_finds '/ shadow connected /' "${listOldAdmin}"
+# Both members advertise the current build's version (the porcelain list's last column)
+# in the released admin's own output: the upgrade replaced the shadow too, not only the
+# master the info check above covers.
+assert_equals 2 "$(echo "${listOldAdmin}" | awk -v v="${SAUNAFS_VERSION}" '$7 == v' | wc -l)"
+
+# The current admin against the current master, in the same cluster, for symmetry: the
+# porcelain status must stay the original three fields (no identity outside a cluster).
+statusNewMaster=$("${new_admin}" metadataserver-status --porcelain localhost "${info[matocl]}")
+assert_equals $'master\trunning' "$(echo "${statusNewMaster}" | cut -f1-2)"
+assert_equals 3 "$(echo "${statusNewMaster}" | awk -F'\t' '{print NF}')"

--- a/tests/tools/saunafs.sh
+++ b/tests/tools/saunafs.sh
@@ -416,6 +416,9 @@ create_sfsmds_cfg_() {
 	fi
 
 	echo "FDB_CLUSTER_FILE = /tmp/saunafs-fdb-test/conf/fdb.cluster"
+	# The default listen host is the wildcard, which is not a dialable address; without a
+	# concrete address to advertise in the cluster registry, an MDS refuses to start.
+	echo "MDS_ADVERTISE_HOST = 127.0.0.1"
 }
 
 create_sfsmaster_shadow_cfg_() {

--- a/tests/tools/saunafsXX.sh
+++ b/tests/tools/saunafsXX.sh
@@ -47,19 +47,23 @@ END
 		echo "deb [arch=amd64 signed-by=${TEMP_DIR}/apt/saunafs-archive-keyring.gpg] https://repo.saunafs.com/repository/saunafs-${distro_id}-${release}/ ${codename} main" >"${TEMP_DIR}/apt/saunafs.list"
 		env APT_CONFIG="${TEMP_DIR}/apt/apt.conf" apt-get update
 		env APT_CONFIG="${TEMP_DIR}/apt/apt.conf" apt-get install --yes libyaml-cpp*
-		SAUNAFSXX_TAG_APT="4.1.0-20240509-152518-stable-main-a7cb5669"
-		if [ "${distro}" == Ubuntu ]; then
-			case "${release}" in
-				'22.04')
-					SAUNAFSXX_TAG_APT="4.1.0-20240509-152513-stable-main-a7cb5669"
-				;;
-				'24.04')
-					SAUNAFSXX_TAG_APT="4.1.0-20240509-152518-stable-main-a7cb5669"
-				;;
-				*)
-					test_fail "Your Ubuntu release (${release}) is not supported."
-				;;
-			esac
+		# A test may pre-set SAUNAFSXX_TAG_APT (together with SAUNAFSXX_TAG) to pin a
+		# different released version; newer releases use plain <version>-<rev> strings.
+		if [ -z "${SAUNAFSXX_TAG_APT:-}" ]; then
+			SAUNAFSXX_TAG_APT="4.1.0-20240509-152518-stable-main-a7cb5669"
+			if [ "${distro}" == Ubuntu ]; then
+				case "${release}" in
+					'22.04')
+						SAUNAFSXX_TAG_APT="4.1.0-20240509-152513-stable-main-a7cb5669"
+					;;
+					'24.04')
+						SAUNAFSXX_TAG_APT="4.1.0-20240509-152518-stable-main-a7cb5669"
+					;;
+					*)
+						test_fail "Your Ubuntu release (${release}) is not supported."
+					;;
+				esac
+			fi
 		fi
 		env APT_CONFIG="${TEMP_DIR}/apt/apt.conf" apt-get --yes --allow-downgrades install --download-only \
 			saunafs-master="${SAUNAFSXX_TAG_APT}" \
@@ -70,8 +74,11 @@ END
 			# saunafs-metalogger="${SAUNAFSXX_TAG_APT}"
 		# unpack binaries
 		(	cd "${destdir}" || return 1
-			find . -name "*master*.deb" -print0 | xargs -0 dpkg-deb --fsys-tarfile | tar -x ./usr/sbin/sfsmaster
-			find . -name "*chunkserver*.deb" -print0 | xargs -0 dpkg-deb --fsys-tarfile | tar -x ./usr/sbin/sfschunkserver
+			# Whole directories, not single members: since 5.x the sfs* names are symlinks
+			# to the leil-* binaries next to them, and extracting just the symlink member
+			# would leave it dangling.
+			find . -name "*master*.deb" -print0 | xargs -0 dpkg-deb --fsys-tarfile | tar -x ./usr/sbin/
+			find . -name "*chunkserver*.deb" -print0 | xargs -0 dpkg-deb --fsys-tarfile | tar -x ./usr/sbin/
 			find . -name "*client*.deb" -print0 | xargs -0 dpkg-deb --fsys-tarfile | tar -x ./usr/bin/
 			find . -name "*adm*.deb" -print0 | xargs -0 dpkg-deb --fsys-tarfile | tar -x ./usr/bin/
 			# find . -name "*metalogger*.deb" -print0 | xargs -0 dpkg-deb --fsys-tarfile | tar -x ./usr/sbin/


### PR DESCRIPTION
Route the list-metadataservers and metadataserver-status handlers
through hooks that default to the exact Master and Shadow logic, so
a KV-backed metadata server can answer both commands with its real
cluster membership instead of reporting itself as a lone running
master. The dispatch turns any exception from a hook into dropping
that one admin connection, so a failed membership read stays
distinguishable from an empty cluster and cannot fail-stop the
process.

metadataserverStatus gains a backward-compatible packet version that
can carry a member id; the list packet stays byte-identical. When the
peer version is unknown, the standalone status command tries the
identity-bearing request first and retries the legacy request on a
fresh connection if an older peer rejects it. The list command selects
its per-member request shape directly from the versions already
present in the list reply.

The admin CLI reports a member whose status query fails as
unreachable instead of aborting the whole listing. New listen
getters report the bound host and port with the listener's own
resolution semantics, registry and heartbeat key prefixes are
reserved in kv_common_keys.h, and the package version moves to
5.12.0 so request shapes can be gated on it.

A new upgrade test proves both commands in all four directions
against the real released 5.11.0 binaries: released admin against
current master and shadow, current admin against a released master
(identity-bearing request rejected, fresh-connection fallback) and a
released shadow (shape selected from the list reply), plus an in-place
upgrade with positive version asserts. Installing rebranded releases
needed a harness fix: the sfs* names in the debs are symlinks since
the rebrand, so the single-member tar extraction unpacked a dangling
link and no binary; install_saunafsXX now extracts the whole usr/sbin/
directory and respects a pre-set SAUNAFSXX_TAG_APT.

Master/Shadow behavior and both commands' output are unchanged. On
its own this is a no-op for them; the hook implementations that
answer from a live cluster registry land with the metadata server
change.

Related to: LS-1003
