### PR TITLE
fix(fdb,master): guard setOption null handle, close wakeup race

### DIFF
--- a/src/fdb/fdb.cc
+++ b/src/fdb/fdb.cc
@@ -248,6 +248,11 @@ fdb_error_t DB::setNetworkOption(FDBNetworkOption option, std::string_view value
 // DB
 
 fdb_error_t DB::setOption(FDBDatabaseOption option, std::string_view value) {
+	// No hermetic test for this guard: fdb_create_database is lazy and succeeds even
+	// for a bogus cluster-file path, deferring failure to first use, so there is no
+	// way to build a DB with db_ == nullptr through the public API (same limitation
+	// as TransactionFromNullDBIsInvalidNotUB in fdb_unittest.cc).
+	if (!db_) { throw std::logic_error("fdb::DB::setOption: database has no backend handle"); }
 	return fdb_database_set_option(db_.get(), option, toU8(value),
 	                               static_cast<int>(value.length()));
 }

--- a/src/fdb/fdb.h
+++ b/src/fdb/fdb.h
@@ -132,6 +132,7 @@ public:
 	}
 
 	/// Wrapper to set an option for the database.
+	/// @throws std::logic_error if the database has no backend handle.
 	fdb_error_t setOption(FDBDatabaseOption option, std::string_view value = {});
 
 private:

--- a/src/master/commit_wakeup_channel.cc
+++ b/src/master/commit_wakeup_channel.cc
@@ -1,0 +1,65 @@
+/*
+   Copyright 2026      Leil Storage OÜ
+
+   This file is part of SaunaFS.
+
+   SaunaFS is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, version 3.
+
+   SaunaFS is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with SaunaFS. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "common/platform.h"
+
+#include <cstdint>
+
+#include <unistd.h>
+
+#include "master/commit_wakeup_channel.h"
+
+void CommitWakeupChannel::arm(int fd) {
+	std::lock_guard<std::mutex> lock(mutex_);
+	fd_ = fd;
+}
+
+void CommitWakeupChannel::wakeup() {
+	std::lock_guard<std::mutex> lock(mutex_);
+	if (fd_ < 0) { return; }
+	uint64_t one = 1;
+	ssize_t written = write(fd_, &one, sizeof(one));
+	(void)written;
+}
+
+void CommitWakeupChannel::pollDesc(std::vector<pollfd> &pdesc) {
+	std::lock_guard<std::mutex> lock(mutex_);
+	if (fd_ < 0) { return; }
+	pdesc.push_back(pollfd{fd_, POLLIN, 0});
+}
+
+void CommitWakeupChannel::pollServe(const std::vector<pollfd> &pdesc) {
+	std::lock_guard<std::mutex> lock(mutex_);
+	if (fd_ < 0) { return; }
+	for (const auto &pfd : pdesc) {
+		if (pfd.fd == fd_ && (pfd.revents & POLLIN) != 0) {
+			uint64_t drain = 0;
+			ssize_t got = read(fd_, &drain, sizeof(drain));
+			(void)got;
+			break;
+		}
+	}
+}
+
+void CommitWakeupChannel::retire() {
+	std::lock_guard<std::mutex> lock(mutex_);
+	if (fd_ >= 0) {
+		close(fd_);
+		fd_ = -1;
+	}
+}

--- a/src/master/commit_wakeup_channel.h
+++ b/src/master/commit_wakeup_channel.h
@@ -1,0 +1,60 @@
+/*
+   Copyright 2026      Leil Storage OÜ
+
+   This file is part of SaunaFS.
+
+   SaunaFS is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, version 3.
+
+   SaunaFS is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with SaunaFS. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "common/platform.h"
+
+#include <mutex>
+#include <vector>
+
+#include <poll.h>
+
+/// Guards an eventfd shared between the master's event-loop thread and the FDB
+/// network thread (which is never joined in production, see fdb::Runtime).
+/// wakeup() is the one call that can arrive from that other thread; every other
+/// method runs on the event-loop thread. The mutex's job is only to serialize
+/// wakeup() against retire(): whichever acquires it first either completes its
+/// write while the fd is still valid, or observes it already cleared and skips.
+/// arm()/pollDesc()/pollServe() take the same lock purely so every touch of the
+/// fd goes through one consistent accessor, not because they need protection
+/// from each other (the event-loop thread already serializes them).
+class CommitWakeupChannel {
+public:
+	/// Registers the fd to signal. Called once from module init.
+	void arm(int fd);
+
+	/// Writes one to the fd if still armed. Called from the FDB network thread's
+	/// future ready-callback; kept minimal, touches only the fd.
+	void wakeup();
+
+	/// pollregister desc: adds the fd to the watch set if still armed.
+	void pollDesc(std::vector<pollfd> &pdesc);
+
+	/// pollregister serve: drains the fd if it was signaled.
+	void pollServe(const std::vector<pollfd> &pdesc);
+
+	/// Invalidates and closes the fd. Called once from matoclserv_term, holds the
+	/// lock through both the invalidation and the close() so no interleaving with
+	/// a concurrent wakeup() is possible.
+	void retire();
+
+private:
+	std::mutex mutex_;
+	int fd_ = -1;  ///< Guarded by mutex_. -1 means unarmed or retired.
+};

--- a/src/master/commit_wakeup_channel_unittest.cc
+++ b/src/master/commit_wakeup_channel_unittest.cc
@@ -1,0 +1,106 @@
+/*
+   Copyright 2026      Leil Storage OÜ
+
+   This file is part of SaunaFS.
+
+   SaunaFS is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, version 3.
+
+   SaunaFS is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with SaunaFS. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "common/platform.h"
+
+#include <atomic>
+#include <cerrno>
+#include <cstdint>
+#include <stdexcept>
+#include <thread>
+
+#include <gtest/gtest.h>
+
+#include <sys/eventfd.h>
+#include <unistd.h>
+
+#include "master/commit_wakeup_channel.h"
+
+namespace {
+
+int openEventFd() {
+	int fd = eventfd(0, EFD_NONBLOCK | EFD_CLOEXEC);
+	if (fd < 0) { throw std::runtime_error("eventfd() failed in test setup"); }
+	return fd;
+}
+
+}  // namespace
+
+TEST(CommitWakeupChannelTests, WakeupPollDescPollServeDrainsFd) {
+	CommitWakeupChannel channel;
+	int fd = openEventFd();
+	channel.arm(fd);
+
+	channel.wakeup();
+
+	std::vector<pollfd> pdesc;
+	channel.pollDesc(pdesc);
+	ASSERT_EQ(1u, pdesc.size());
+	EXPECT_EQ(fd, pdesc[0].fd);
+
+	pdesc[0].revents = POLLIN;
+	channel.pollServe(pdesc);
+
+	uint64_t drained = 0;
+	EXPECT_EQ(-1, read(fd, &drained, sizeof(drained)));
+	EXPECT_EQ(EAGAIN, errno);
+
+	channel.retire();
+}
+
+// Stresses wakeup() (simulating the FDB network thread) against repeated
+// retire()/arm() cycles (simulating shutdown racing an in-flight commit).
+// This proves wakeup() and retire() never touch fd_ concurrently (no TSAN
+// report), which is what the mutex is for. It does not independently prove
+// fd-reuse safety: TSAN instruments the C++ memory model, not OS fd lifetime,
+// so a hypothetical wakeup() that copied fd_ out and wrote after unlocking
+// would still pass this test clean. That guarantee instead comes from
+// wakeup()'s write() sitting fully inside its own critical section, and
+// retire()'s close() sitting fully inside its critical section too, so
+// wakeup() can never observe a half-invalidated fd_.
+TEST(CommitWakeupChannelTests, WakeupDoesNotRaceRetire) {
+	CommitWakeupChannel channel;
+	channel.arm(openEventFd());
+
+	std::atomic<bool> stop{false};
+	std::thread wakeupThread([&channel, &stop]() {
+		while (!stop.load(std::memory_order_relaxed)) { channel.wakeup(); }
+	});
+
+	constexpr int kCycles = 2000;
+	for (int i = 0; i < kCycles; ++i) {
+		channel.retire();
+		channel.arm(openEventFd());
+	}
+
+	stop.store(true, std::memory_order_relaxed);
+	wakeupThread.join();
+	channel.retire();
+
+	// Retired state must be terminal and harmless to poke further: no fd left
+	// to watch, and a lagging wakeup() (or a repeated retire(), as shutdown
+	// could plausibly do) must not resurrect it.
+	std::vector<pollfd> pdescAfterRetire;
+	channel.pollDesc(pdescAfterRetire);
+	EXPECT_TRUE(pdescAfterRetire.empty());
+
+	channel.wakeup();
+	channel.retire();
+	channel.pollDesc(pdescAfterRetire);
+	EXPECT_TRUE(pdescAfterRetire.empty());
+}

--- a/src/master/matoclserv.cc
+++ b/src/master/matoclserv.cc
@@ -40,7 +40,6 @@
 #include <time.h>
 #include <unistd.h>
 #include <algorithm>
-#include <atomic>
 #include <bit>
 #include <chrono>
 #include <cstdint>
@@ -88,6 +87,7 @@
 #include "master/chunk_operations_interface.h"
 #include "master/chunks.h"
 #include "master/chunkserver_db.h"
+#include "master/commit_wakeup_channel.h"
 #include "master/datacachemgr.h"
 #include "master/exports.h"
 #include "master/filesystem.h"
@@ -279,47 +279,38 @@ static uint32_t gDebugInjectReadConflicts = 0;
 // retry loop. Counted per process. Reloadable. Leave 0 in production.
 static uint32_t gDebugInjectRecoveryErrors = 0;
 
-// eventfd the commit future's ready callback writes to (from the backend network
-// thread, or inline from the event-loop thread) so poll() wakes immediately to
-// finalize the commit instead of waiting out the poll timeout. -1 until
-// matoclserv_network_init creates it. Linux-only; without it the group commit path
-// still works, just serviced at the poll-timeout cadence.
-static std::atomic<int> gCommitWakeupFd{-1};
+namespace {
+
+CommitWakeupChannel &commitWakeupChannel() {
+	// Deliberately leaked (never deleted): mirrors fdb::Runtime's globalCore
+	// (fdb_runtime.cc:203-213). The FDB network thread is never joined before
+	// process exit, so it may still call wakeup() after ordinary static
+	// destructors would have run; an ordinary static object here would
+	// register a destructor that could then lock/use an already-destroyed
+	// mutex, which is undefined behavior.
+	static CommitWakeupChannel *channel = new CommitWakeupChannel();
+	return *channel;
+}
+
+}  // namespace
 
 /// Wakes the event loop when a batch commit becomes durable. Invoked from the
 /// backend network thread, so it stays minimal and touches only the eventfd. The
 /// write is best-effort: if the 64-bit counter is somehow saturated the existing
 /// pending value still keeps poll() readable, and a dropped wakeup only defers
 /// finalization to the next poll.
-static void matoclserv_commit_wakeup(void * /*arg*/) {
-	int fd = gCommitWakeupFd.load(std::memory_order_acquire);
-	if (fd < 0) { return; }
-	uint64_t one = 1;
-	ssize_t written = write(fd, &one, sizeof(one));
-	(void)written;
-}
+static void matoclserv_commit_wakeup(void * /*arg*/) { commitWakeupChannel().wakeup(); }
 
 /// pollregister desc: have poll() watch the wakeup eventfd for readability.
 static void matoclserv_commit_wakeup_desc(std::vector<pollfd> &pdesc) {
-	int fd = gCommitWakeupFd.load(std::memory_order_acquire);
-	if (fd < 0) { return; }
-	pdesc.push_back(pollfd{fd, POLLIN, 0});
+	commitWakeupChannel().pollDesc(pdesc);
 }
 
 /// pollregister serve: drain the eventfd so it stops signalling. The matching
 /// commit finalization runs in matoclserv_poll_batch (an eachloop hook
 /// that fires every iteration regardless), so this only clears the wakeup.
 static void matoclserv_commit_wakeup_serve(const std::vector<pollfd> &pdesc) {
-	int fd = gCommitWakeupFd.load(std::memory_order_acquire);
-	if (fd < 0) { return; }
-	for (const auto &pfd : pdesc) {
-		if (pfd.fd == fd && (pfd.revents & POLLIN) != 0) {
-			uint64_t drain = 0;
-			ssize_t got = read(fd, &drain, sizeof(drain));
-			(void)got;
-			break;
-		}
-	}
+	commitWakeupChannel().pollServe(pdesc);
 }
 
 /// Last changelog version handed to KV changelog sinks.
@@ -7266,12 +7257,10 @@ void matoclserv_term() {
 	gOpenBatch.hasContext = false;
 	gOpenBatch.ctx = FilesystemOperationContext();
 
-	// Invalidate before closing so a commit-wakeup callback racing in from the backend
-	// network thread reads -1 (and skips the write) instead of touching a closed fd.
-	int wakeupFd = gCommitWakeupFd.exchange(-1, std::memory_order_acq_rel);
-	if (wakeupFd >= 0) {
-		close(wakeupFd);
-	}
+	// CommitWakeupChannel::retire() holds its lock through both the invalidation and
+	// the close(), so a commit-wakeup callback racing in from the backend network
+	// thread either finishes its write first or observes the fd already cleared.
+	commitWakeupChannel().retire();
 
 	for (const auto &eptr : matoclservList) {
 		eptr->delayedChunkOperations.clear();
@@ -7780,7 +7769,7 @@ int matoclserv_network_init() {
 	// completing on the backend network thread wakes the loop immediately. Non-fatal if
 	// it fails (EFD missing): the deferred path then runs at poll-timeout cadence.
 	int wakeupFd = eventfd(0, EFD_NONBLOCK | EFD_CLOEXEC);
-	gCommitWakeupFd.store(wakeupFd, std::memory_order_release);
+	commitWakeupChannel().arm(wakeupFd);
 	if (wakeupFd < 0) {
 		safs::log_warn("main master server module: eventfd for async commit wakeup failed: {}",
 		               strerr(errno));


### PR DESCRIPTION
Two small, independent fixes found during LS-962 review and left unfixed
until now.

DB::setOption forwarded a possibly-null db_ straight into
fdb_database_set_option, unlike Transaction::setOption, which already
guards via requireActive/requireHandle. Mirrors that convention: throws
std::logic_error naming the missing handle instead of passing null into
the C API. Not reachable through any call path today (DB is only ever
constructed by FDBContext::getDB(), which never hands out a null-handle
DB), but closes a real asymmetry with the transaction-side guard.

matoclserv_commit_wakeup fires on the FDB network thread, which
production never joins (the runtime singleton is deliberately leaked).
matoclserv_term invalidates and closes the wakeup eventfd on the
event-loop thread with no ordering guarantee against a callback already
in flight: it could load the old fd before invalidation and write to it
after close(), and the OS may have already reassigned that fd number to
something unrelated by the time the write lands. Extracts the fd and its
guard into CommitWakeupChannel, a small class whose mutex serializes
wakeup() against retire(): whichever acquires it first either completes
its write while the fd is still valid, or observes it already cleared
and skips. A new stress test hammers wakeup() against repeated
retire()/arm() cycles from a separate thread, then checks the retired
state stays terminal (no pollDesc() entries, harmless repeated
wakeup()/retire()).

Related to: LS-962