### PR TITLE
fix(master): abort batch effects before replay

### DIFF
--- a/src/master/matoclserv.cc
+++ b/src/master/matoclserv.cc
@@ -765,6 +765,10 @@ static void matoclserv_finish_member(BatchMember &member, uint8_t status) {
 /// already wrote and the backend cannot undo a single op. The caller then restarts the
 /// replay on a fresh transaction. Shared by the whole-batch replay and the single-member
 /// join.
+///
+/// Every unusable-transaction exit delivers the context's abort before anything else
+/// runs: members that already ran may have left eager effects on the context, and both
+/// the finish callbacks below and the rebuilt replay would otherwise observe them.
 static bool matoclserv_replay_members_iteration(std::vector<BatchMember> &members, size_t &idx,
                                                 FilesystemOperationContext &ctx) {
 	auto *txn = ctx.getReadWriteTransaction();
@@ -782,12 +786,14 @@ static bool matoclserv_replay_members_iteration(std::vector<BatchMember> &member
 			return false;
 		}
 		const bool poisoned = txn != nullptr && txn->mutationCount() != mutationsBefore;
+		if (poisoned) { ctx.finishTransactionEffects(FilesystemTransactionOutcome::kAborted); }
 		matoclserv_finish_member(member, status);
 		members.erase(members.begin() + idx);
 		return poisoned;
 	} catch (const kv::RetryableTransactionError &e) {
 		// The shared transaction is invalid after a thrown read error:
 		// restart on a fresh one regardless of what this member did.
+		ctx.finishTransactionEffects(FilesystemTransactionOutcome::kAborted);
 		if (member.attempts >= gMaxCommitRetries) {
 			safs::log_warn(
 			    "matoclserv: batch member read retry exhausted after {} attempts (err {}): {}",
@@ -806,6 +812,7 @@ static bool matoclserv_replay_members_iteration(std::vector<BatchMember> &member
 		// Non-retryable backend failure: fail this member with EIO and restart the batch
 		// on a fresh transaction (the shared transaction is unusable after a thrown
 		// error).
+		ctx.finishTransactionEffects(FilesystemTransactionOutcome::kAborted);
 		safs::log_err("matoclserv: backend transaction error in batch member (err {}): {}",
 		              e.errorCode(), e.what());
 		matoclserv_finish_member(member, SAUNAFS_ERROR_IO);


### PR DESCRIPTION
Batched client operations share one backend transaction. When a member
fails in a way that makes that transaction unusable (a retryable read
error, or a failure after the transaction already wrote), the whole
transaction is discarded and the surviving members are replayed: a
fresh transaction is built and their operation bodies rerun from the
start.

Some backends let an operation body update the master's in-memory
state while it runs. Those updates are provisional: they are attached
to the operation's context as effects, and when the context is told
the operation aborted, the effects are rolled back so memory matches
what the backend actually committed, which is nothing.

The bug was the timing of that abort notification. It was delivered
only when the context was destroyed, and destruction happens after
the replay. Concretely, with members A and B sharing a transaction:
A's body updates in-memory bookkeeping, then hits a retryable error
that invalidates the shared transaction. Replay reruns A and B on a
fresh transaction, but A's rollback has not run yet, so the rerun of
A starts from the failed attempt's bookkeeping instead of clean
state. A body can then take a different branch than a first run
would, acting on state that was never committed.

Deliver the context's abort inside the per-member replay step, on
every exit where the transaction is unusable, before member finish
callbacks run and before any rebuild. Outcome delivery is exactly
once, so the later destruction of the context stays a no-op.
Backends that attach no effects to the context are unchanged by
construction.

Related to: LS-868
