### PR TITLE
fix(ci): pin Fedora container to stable 44

### DIFF
--- a/.github/workflows/fedora-rpm-build-review.yml
+++ b/.github/workflows/fedora-rpm-build-review.yml
@@ -11,7 +11,7 @@ jobs:
   build-and-test:
     runs-on: ubuntu-latest
     container:
-      image: fedora:rawhide
+      image: fedora:44
       options: --privileged
 
     steps:


### PR DESCRIPTION
Rawhide's rolling primary-key rotation caused a transient GPG verification failure on an openh264 dependency during dnf install. Pin to fedora:44 (current stable) instead of rawhide or floating latest, so CI stays fully reproducible and a future failure means something in the repo broke, not that Fedora moved under it.