### PR TITLE
feat(master): add chunk maintenance switch

### DIFF
--- a/src/master/chunks.cc
+++ b/src/master/chunks.cc
@@ -232,6 +232,12 @@ static uint32_t ChunksLoopTimeout;
 static double   gAcceptableDifference;
 static bool     RebalancingBetweenLabels = false;
 
+// Whether this server issues background chunk maintenance commands (repair, replication,
+// physical deletion, rebalancing). Default true; an embedding server may turn it off before
+// promotion. The chunk worker still runs either way: its per-chunk statistics refresh is
+// required by client write and truncate paths and must not depend on this flag.
+static bool gChunkMaintenanceEnabled = true;
+
 static uint32_t jobsnorepbefore;
 
 constexpr uint32_t kStartupGracePeriodSeconds = 60;
@@ -2899,6 +2905,12 @@ void ChunkWorker::doChunkJobs(Chunk *c, uint16_t serverCount) {
 	// Useful e.g. if definitions of goals did change.
 	chunk_handle_disconnected_copies(c);
 	c->updateStats();
+
+	// Skip maintenance planning and commands after completing required bookkeeping.
+	if (!gChunkMaintenanceEnabled) {
+		return;
+	}
+
 	if (serverCount == 0) {
 		return;
 	}
@@ -3172,6 +3184,8 @@ void ChunkWorker::mainLoop() {
 
 static std::unique_ptr<ChunkWorker> gChunkWorker;
 
+void chunk_set_maintenance_enabled(bool enabled) { gChunkMaintenanceEnabled = enabled; }
+
 void chunk_jobs_main(void) {
 	if (gChunkWorker->is_complete()) {
 		gChunkWorker->reset();
@@ -3311,6 +3325,9 @@ void chunk_newfs(void) {
 void chunk_become_master() {
 	starttime = eventloop_time();
 	jobsnorepbefore = starttime + gOperationsDelayInit;
+	if (!gChunkMaintenanceEnabled) {
+		safs::log_info("background chunk maintenance commands disabled by config");
+	}
 	gChunkWorker = std::unique_ptr<ChunkWorker>(new ChunkWorker());
 	gChunkLoopEventHandle = eventloop_timeregister_ms(ChunksLoopPeriod, chunk_jobs_main);
 	eventloop_eachloopregister(chunk_jobs_process_bit);

--- a/src/master/chunks.h
+++ b/src/master/chunks.h
@@ -152,6 +152,14 @@ int chunk_can_unlock(uint64_t chunkid, uint32_t lockid);
 
 int chunk_invalidate_goal_cache();
 
+/// Enables or disables background chunk maintenance commands (repair, replication, physical
+/// deletion, rebalancing) sent to chunkservers. Must be called before promotion; the default is
+/// enabled. The chunk worker keeps running either way: it still refreshes each chunk's cached
+/// statistics, which client write and truncate paths rely on, and still drops already-empty
+/// in-memory chunk records. Foreground client operations and their recovery stay enabled; only
+/// the listed background maintenance commands are suppressed.
+void chunk_set_maintenance_enabled(bool enabled);
+
 #endif
 
 bool chunksLoadFromFile(MetadataLoader::Options);


### PR DESCRIPTION
Add a switch that lets an MDS stop background chunk repair, replication, copy deletion, and rebalancing.

Keep the chunk worker running so chunk statistics stay current and client requests continue to work. The switch is enabled by default, so Master behavior does not change.

Related to: LS-1060