### PR TITLE
ci: fix git clone for docker image building

### DIFF
--- a/tests/docker/Dockerfile.test
+++ b/tests/docker/Dockerfile.test
@@ -63,6 +63,8 @@ COPY tests ./tests
 COPY COPYING .
 COPY README.md .
 
+RUN git config --global http.version HTTP/1.1
+
 RUN mkdir -p /leilfs/build && ls /leilfs && \
     cd /leilfs/build && cmake \
 	-DCMAKE_TOOLCHAIN_FILE="/leilfs/vcpkg/scripts/buildsystems/vcpkg.cmake" \


### PR DESCRIPTION
Configure Git to use HTTP/1.1 to avoid GitHub clone failures caused by HTTP/2.0 during the Docker build. Because git clone used HTTP/2.0 by default and asked for username and password, which caused build pipelines to fail.