### PR TITLE
ci: fetch nfs-ganesha with the job credential

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -23,7 +23,29 @@ def getLeilTestsRef() {
 // GitHub fetch in the pipeline reuses it: GitHub refuses anonymous clones often enough to
 // break builds, and an anonymous clone is the only kind cmake can run inside a Docker build.
 def githubCredentialsId() {
-    return scm.userRemoteConfigs[0].credentialsId
+    def credentialsId = scm.userRemoteConfigs[0].credentialsId
+    if (!credentialsId) {
+        // Not fatal: an anonymous fetch is what this pipeline did before, and it still works
+        // whenever GitHub is not throttling.
+        echo 'WARNING: the job SCM carries no credential, so GitHub fetches run anonymously ' +
+             'and may fail with a 401 from GitHub\'s anti-abuse protection.'
+    }
+    return credentialsId
+}
+
+// Reads a KEY=value setting out of ganesha.env. Fails loudly rather than checking out
+// refs/tags/ from an empty URL if the file ever stops carrying the setting.
+def ganeshaEnvVar(String text, String key) {
+    def prefix = "${key}="
+    for (line in text.split('\n')) {
+        if (line.startsWith(prefix)) {
+            def value = line.substring(prefix.length()).trim()
+            if (value) {
+                return value
+            }
+        }
+    }
+    error("${key} is missing or empty in tests/ci_build/ganesha/ganesha.env")
 }
 
 // cmake clones nfs-ganesha at configure time (cmake/DownloadExternal.cmake) unless
@@ -32,15 +54,9 @@ def githubCredentialsId() {
 // The Dockerfile copies external/ into the image and cmake then finds the directory and skips
 // the clone. Tag and URL come from tests/ci_build/ganesha/ganesha.env, the single source of truth.
 def fetchGanesha() {
-    def ganeshaEnv = 'tests/ci_build/ganesha/ganesha.env'
-    def tag = sh(
-        script: "sed -n 's/^GANESHA_VERSION=//p' ${ganeshaEnv}",
-        returnStdout: true
-    ).trim()
-    def url = sh(
-        script: "sed -n 's/^GANESHA_GIT_URL=//p' ${ganeshaEnv}",
-        returnStdout: true
-    ).trim()
+    def ganeshaEnv = readFile('tests/ci_build/ganesha/ganesha.env')
+    def tag = ganeshaEnvVar(ganeshaEnv, 'GANESHA_VERSION')
+    def url = ganeshaEnvVar(ganeshaEnv, 'GANESHA_GIT_URL')
     // Directory name keeps the numeric form (V9.15 -> nfs-ganesha-9.15), like Libraries.cmake.
     def version = tag.replaceFirst(/^[Vv]/, '')
     dir("external/nfs-ganesha-${version}") {
@@ -61,6 +77,13 @@ def fetchGanesha() {
             ]]
         ])
     }
+}
+
+// Every stage that builds leilfs needs both halves: this repository, and the Ganesha source
+// cmake expects in external/. Kept in one step so a new stage cannot pick up only the first.
+def checkoutSource() {
+    checkout scm
+    fetchGanesha()
 }
 
 def buildLeilTests() {
@@ -261,8 +284,7 @@ pipeline {
                     stages {
                         stage("Checkout source") {
                             steps {
-                                checkout scm
-                                fetchGanesha()
+                                checkoutSource()
                             }
                         }
                         stage("Build and unit test") {
@@ -327,8 +349,7 @@ pipeline {
                 stage('Build with clang') {
                     agent {label 'build'}
                     steps {
-                        checkout scm
-                        fetchGanesha()
+                        checkoutSource()
                         script {
                             sh """
                                 docker buildx build --tag leilfs-clang-build:latest -f tests/docker/Dockerfile.test $WORKSPACE
@@ -366,8 +387,7 @@ pipeline {
                     stages {
                         stage("Checkout source") {
                             steps {
-                                checkout scm
-                                fetchGanesha()
+                                checkoutSource()
                             }
                         }
                         stage('Build image') {
@@ -412,8 +432,7 @@ pipeline {
                     stages {
                         stage("Checkout source") {
                             steps {
-                                checkout scm
-                                fetchGanesha()
+                                checkoutSource()
                             }
                         }
                         stage('Build leil-tests') {
@@ -510,8 +529,7 @@ pipeline {
                     stages {
                         stage("Checkout source") {
                             steps {
-                                checkout scm
-                                fetchGanesha()
+                                checkoutSource()
                             }
                         }
                         stage('Build leil-tests') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,6 +19,50 @@ def getLeilTestsRef() {
     return ref
 }
 
+// The multibranch job checks this repository out with a GitHub App credential. Every other
+// GitHub fetch in the pipeline reuses it: GitHub refuses anonymous clones often enough to
+// break builds, and an anonymous clone is the only kind cmake can run inside a Docker build.
+def githubCredentialsId() {
+    return scm.userRemoteConfigs[0].credentialsId
+}
+
+// cmake clones nfs-ganesha at configure time (cmake/DownloadExternal.cmake) unless
+// external/nfs-ganesha-<version> already exists. That clone runs anonymously inside the image
+// build and on the host build, so check the pinned tag out here with the job credential first.
+// The Dockerfile copies external/ into the image and cmake then finds the directory and skips
+// the clone. Tag and URL come from tests/ci_build/ganesha/ganesha.env, the single source of truth.
+def fetchGanesha() {
+    def ganeshaEnv = 'tests/ci_build/ganesha/ganesha.env'
+    def tag = sh(
+        script: "sed -n 's/^GANESHA_VERSION=//p' ${ganeshaEnv}",
+        returnStdout: true
+    ).trim()
+    def url = sh(
+        script: "sed -n 's/^GANESHA_GIT_URL=//p' ${ganeshaEnv}",
+        returnStdout: true
+    ).trim()
+    // Directory name keeps the numeric form (V9.15 -> nfs-ganesha-9.15), like Libraries.cmake.
+    def version = tag.replaceFirst(/^[Vv]/, '')
+    dir("external/nfs-ganesha-${version}") {
+        checkout([
+            $class: 'GitSCM',
+            branches: [[name: "refs/tags/${tag}"]],
+            extensions: [
+                // Shallow fetch of the pinned tag only; noTags keeps git from pulling every tag.
+                [$class: 'CloneOption', shallow: true, depth: 1, noTags: true, honorRefspec: true],
+                // libntirpc is a GitHub submodule as well, so it needs the same credential.
+                [$class: 'SubmoduleOption', recursiveSubmodules: true, parentCredentials: true,
+                 shallow: true, depth: 1]
+            ],
+            userRemoteConfigs: [[
+                url: url,
+                refspec: "+refs/tags/${tag}:refs/tags/${tag}",
+                credentialsId: githubCredentialsId()
+            ]]
+        ])
+    }
+}
+
 def buildLeilTests() {
     dir('leil-tests') {
         deleteDir()
@@ -27,7 +71,8 @@ def buildLeilTests() {
             branches: [[name: getLeilTestsRef()]],
             doGenerateSubmoduleConfigurations: false,
             userRemoteConfigs: [[
-                url: 'https://github.com/leil-io/leil-tests.git'
+                url: 'https://github.com/leil-io/leil-tests.git',
+                credentialsId: githubCredentialsId()
             ]]
         ])
     }
@@ -217,6 +262,7 @@ pipeline {
                         stage("Checkout source") {
                             steps {
                                 checkout scm
+                                fetchGanesha()
                             }
                         }
                         stage("Build and unit test") {
@@ -282,6 +328,7 @@ pipeline {
                     agent {label 'build'}
                     steps {
                         checkout scm
+                        fetchGanesha()
                         script {
                             sh """
                                 docker buildx build --tag leilfs-clang-build:latest -f tests/docker/Dockerfile.test $WORKSPACE
@@ -320,6 +367,7 @@ pipeline {
                         stage("Checkout source") {
                             steps {
                                 checkout scm
+                                fetchGanesha()
                             }
                         }
                         stage('Build image') {
@@ -365,6 +413,7 @@ pipeline {
                         stage("Checkout source") {
                             steps {
                                 checkout scm
+                                fetchGanesha()
                             }
                         }
                         stage('Build leil-tests') {
@@ -462,6 +511,7 @@ pipeline {
                         stage("Checkout source") {
                             steps {
                                 checkout scm
+                                fetchGanesha()
                             }
                         }
                         stage('Build leil-tests') {

--- a/cmake/Libraries.cmake
+++ b/cmake/Libraries.cmake
@@ -145,6 +145,8 @@ if(ENABLE_NFS_GANESHA)
   # Clone at the pinned tag WITH submodules so src/libntirpc is checked out at the
   # exact commit this release pins. ntirpc thus tracks the Ganesha version with no
   # separate pin to maintain (a source zip would omit the submodule entirely).
+  # CI checks this directory out beforehand with its GitHub credential (Jenkinsfile,
+  # fetchGanesha), so on Jenkins the clone below finds it and is skipped.
   clone_external_git(NFS_GANESHA "nfs-ganesha-${NFS_GANESHA_VERSION}"
                      "${GANESHA_GIT_URL}" "${GANESHA_GIT_TAG}")
   # ntirpc headers live inside the Ganesha submodule checkout.


### PR DESCRIPTION
cmake clones nfs-ganesha at configure time, anonymously, both inside the Docker image build and on the host build. GitHub has been refusing anonymous clones from Debian and Ubuntu git since 2026-09-02, so every image build died at that step.

Check the pinned tag out in the Jenkinsfile with the GitHub App credential the job already uses for its own checkout, into external/nfs-ganesha-<version>. The Dockerfile copies external/ into the image and cmake finds the directory and skips the clone. Tag and URL still come from tests/ci_build/ganesha/ganesha.env.

The leil-tests checkout reuses the same credential so no GitHub fetch in the pipeline runs anonymously.