### PR TITLE
feat(chunkserver): persist a stable UUID

### DIFF
--- a/doc/leil-chunkserver.8.adoc
+++ b/doc/leil-chunkserver.8.adoc
@@ -67,6 +67,10 @@ freed by replicating all data already stored there to another locations)
 *.sfschunkserver.lock*:: lock file of running LeilFS chunkserver process
 (created in data directory)
 
+*chunkserver_id*:: stable UUID of this chunkserver installation, created in the
+data directory during startup when missing. Copying the complete data directory
+preserves the identity. Running two copies with the same identity is not supported.
+
 *data.csstats*::
 Chunkserver charts state
 

--- a/doc/leil-chunkserver.cfg.5.adoc
+++ b/doc/leil-chunkserver.cfg.5.adoc
@@ -22,7 +22,7 @@ Lines starting with *#* character are ignored.
 
 Configuration options:
 
-*DATA_PATH*:: where to store files with usage statistics and daemon lock file
+*DATA_PATH*:: where to store the chunkserver identity, usage statistics, and daemon lock file
 
 *LABEL*:: the label of this chunkserver (for tiering)
 

--- a/src/chunkserver/README.md
+++ b/src/chunkserver/README.md
@@ -516,20 +516,21 @@ is dependency-ordered:
 
 ```
  Normal run:
-  1. rnd_init                -- Random number generator
-  2. MemoryManager::init     -- Periodic malloc_trim thread
-  3. initDiskManager         -- Create DefaultDiskManager (before plugins)
-  4. loadPlugins             -- Load .so plugins via PluginManager
-  5. hddInit                 -- Parse hdd.cfg, create/reload disks, prepare scan state
-  6. mainNetworkThreadInit   -- Bind listen socket (before masterconn)
-  7. masterconn_init_threads -- Create master MasterJobPool + replication job pool (MasterJobPool)
-  8. masterconn_init         -- Create MasterConn, register event loop hooks
-  9. chartsdata_init         -- Charts/monitoring initialization
+  1. chunkserverIdInit       -- Load or create the persistent chunkserver identity
+  2. rnd_init                -- Random number generator
+  3. MemoryManager::init     -- Periodic malloc_trim thread
+  4. initDiskManager         -- Create DefaultDiskManager (before plugins)
+  5. loadPlugins             -- Load .so plugins via PluginManager
+  6. hddInit                 -- Parse hdd.cfg, create/reload disks, prepare scan state
+  7. mainNetworkThreadInit   -- Bind listen socket (before masterconn)
+  8. masterconn_init_threads -- Create master MasterJobPool + replication job pool (MasterJobPool)
+  9. masterconn_init         -- Create MasterConn, register event loop hooks
+ 10. chartsdata_init         -- Charts/monitoring initialization
 
  Late run (after init):
- 10. hddLateInit             -- Spawn disk-management, tester, free-resource, and
+ 11. hddLateInit             -- Spawn disk-management, tester, free-resource, and
                                 client-reported-test threads
- 11. mainNetworkThreadInitThreads -- Spawn network worker threads
+ 12. mainNetworkThreadInitThreads -- Spawn network worker threads
 ```
 
 Client connections are accepted only after all subsystems are ready.

--- a/src/chunkserver/chunkserver_id.cc
+++ b/src/chunkserver/chunkserver_id.cc
@@ -1,0 +1,274 @@
+/*
+   Copyright 2026      Leil Storage OÜ
+
+   This file is part of SaunaFS.
+
+   SaunaFS is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, version 3.
+
+   SaunaFS is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with SaunaFS. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "common/platform.h"
+
+#include <fcntl.h>
+#include <fmt/format.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#include <algorithm>
+#include <array>
+#include <boost/uuid/random_generator.hpp>
+#include <boost/uuid/string_generator.hpp>
+#include <boost/uuid/uuid.hpp>
+#include <boost/uuid/uuid_io.hpp>
+#include <cerrno>
+#include <cstddef>
+#include <cstdint>
+#include <filesystem>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <system_error>
+
+#include "chunkserver/chunkserver_id.h"
+#include "common/cwrap.h"
+#include "common/massert.h"
+#include "slogger/slogger.h"
+
+namespace chunkserver {
+
+namespace {
+
+constexpr size_t kUuidTextSize = 36;
+constexpr size_t kUuidFileSize = kUuidTextSize + 1;
+
+std::optional<ChunkserverId> gChunkserverId;
+
+[[noreturn]] void throwSystemError(const std::string &operation, int errorNumber) {
+	throw std::system_error(errorNumber, std::generic_category(), operation);
+}
+
+boost::uuids::uuid asBoostUuid(const ChunkserverId &chunkserverId) {
+	boost::uuids::uuid uuid;
+	std::ranges::copy(chunkserverId, uuid.begin());
+	return uuid;
+}
+
+ChunkserverId fromBoostUuid(const boost::uuids::uuid &uuid) {
+	ChunkserverId chunkserverId{};
+	std::ranges::copy(uuid, chunkserverId.begin());
+	return chunkserverId;
+}
+
+bool isVersion4(const boost::uuids::uuid &uuid) {
+	return uuid.version() == boost::uuids::uuid::version_random_number_based &&
+	       uuid.variant() == boost::uuids::uuid::variant_rfc_4122;
+}
+
+[[noreturn]] void throwNotCanonicalUuid() {
+	throw std::invalid_argument("chunkserver id is not a canonical lowercase UUIDv4");
+}
+
+void validateGeneratedChunkserverId(const ChunkserverId &chunkserverId) {
+	if (!isVersion4(asBoostUuid(chunkserverId))) {
+		throw std::runtime_error("chunkserver id generator did not return a UUIDv4");
+	}
+}
+
+void closeFile(FileDescriptor &file, const std::filesystem::path &path) {
+	if (::close(file.release()) != 0) {
+		throwSystemError(fmt::format("failed to close '{}'", path.string()), errno);
+	}
+}
+
+std::optional<ChunkserverId> readChunkserverId(const std::filesystem::path &path) {
+	const int descriptor = ::open(path.c_str(), O_RDONLY | O_CLOEXEC | O_NOFOLLOW | O_NONBLOCK);
+	if (descriptor < 0) {
+		if (errno == ENOENT) { return std::nullopt; }
+		throwSystemError(fmt::format("failed to open existing chunkserver id '{}'", path.string()),
+		                 errno);
+	}
+	FileDescriptor file(descriptor);
+
+	struct stat status {};
+	if (::fstat(file.get(), &status) != 0) {
+		throwSystemError(fmt::format("failed to inspect chunkserver id '{}'", path.string()),
+		                 errno);
+	}
+	if (!S_ISREG(status.st_mode) || (status.st_size != static_cast<off_t>(kUuidTextSize) &&
+	                                 status.st_size != static_cast<off_t>(kUuidFileSize))) {
+		throw std::runtime_error(
+		    fmt::format("chunkserver id '{}' is not a canonical UUIDv4 file", path.string()));
+	}
+
+	std::array<char, kUuidFileSize> content{};
+	size_t offset = 0;
+	const size_t expectedSize = static_cast<size_t>(status.st_size);
+	while (offset < expectedSize) {
+		const ssize_t bytesRead =
+		    ::read(file.get(), content.data() + offset, expectedSize - offset);
+		if (bytesRead < 0) {
+			if (errno == EINTR) { continue; }
+			throwSystemError(fmt::format("failed to read chunkserver id '{}'", path.string()),
+			                 errno);
+		}
+		if (bytesRead == 0) {
+			throw std::runtime_error(
+			    fmt::format("chunkserver id '{}' ended before its expected size", path.string()));
+		}
+		offset += static_cast<size_t>(bytesRead);
+	}
+	closeFile(file, path);
+
+	return parseChunkserverId(std::string_view(content.data(), expectedSize));
+}
+
+void writeAll(int descriptor, std::string_view content, const std::filesystem::path &path) {
+	size_t offset = 0;
+	while (offset < content.size()) {
+		const ssize_t bytesWritten =
+		    ::write(descriptor, content.data() + offset, content.size() - offset);
+		if (bytesWritten < 0) {
+			if (errno == EINTR) { continue; }
+			throwSystemError(fmt::format("failed to write chunkserver id to '{}'", path.string()),
+			                 errno);
+		}
+		if (bytesWritten == 0) {
+			throw std::runtime_error(
+			    fmt::format("writing chunkserver id to '{}' made no progress", path.string()));
+		}
+		offset += static_cast<size_t>(bytesWritten);
+	}
+}
+
+bool directorySyncUnsupported(int errorNumber) {
+	return errorNumber == EINVAL || errorNumber == EOPNOTSUPP;
+}
+
+void syncParentDirectory(const std::filesystem::path &path) {
+	const std::filesystem::path parent = path.parent_path().empty() ? "." : path.parent_path();
+	const int descriptor = ::open(parent.c_str(), O_RDONLY | O_CLOEXEC | O_DIRECTORY);
+	if (descriptor < 0) {
+		throwSystemError(
+		    fmt::format("failed to open chunkserver id directory '{}'", parent.string()), errno);
+	}
+	FileDescriptor directory(descriptor);
+
+	if (::fsync(directory.get()) != 0) {
+		const int errorNumber = errno;
+		if (directorySyncUnsupported(errorNumber)) {
+			safs::log_warn("filesystem does not support syncing chunkserver id directory '{}': {}",
+			               parent.string(), errorString(errorNumber));
+		} else {
+			throwSystemError(
+			    fmt::format("failed to sync chunkserver id directory '{}'", parent.string()),
+			    errorNumber);
+		}
+	}
+	closeFile(directory, parent);
+}
+
+void persistChunkserverId(const std::filesystem::path &path, const ChunkserverId &chunkserverId) {
+	const std::filesystem::path temporaryPath = path.string() + ".tmp";
+	if (::unlink(temporaryPath.c_str()) != 0 && errno != ENOENT) {
+		throwSystemError(
+		    fmt::format("failed to remove stale chunkserver id file '{}'", temporaryPath.string()),
+		    errno);
+	}
+
+	try {
+		const int descriptor =
+		    ::open(temporaryPath.c_str(), O_WRONLY | O_CREAT | O_EXCL | O_CLOEXEC,
+		           S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH);
+		if (descriptor < 0) {
+			throwSystemError(
+			    fmt::format("failed to create chunkserver id file '{}'", temporaryPath.string()),
+			    errno);
+		}
+		FileDescriptor temporaryFile(descriptor);
+		const std::string content = formatChunkserverId(chunkserverId) + "\n";
+
+		writeAll(temporaryFile.get(), content, temporaryPath);
+		if (::fsync(temporaryFile.get()) != 0) {
+			throwSystemError(
+			    fmt::format("failed to sync chunkserver id file '{}'", temporaryPath.string()),
+			    errno);
+		}
+		closeFile(temporaryFile, temporaryPath);
+
+		if (::rename(temporaryPath.c_str(), path.c_str()) != 0) {
+			throwSystemError(fmt::format("failed to rename chunkserver id file '{}' to '{}'",
+			                             temporaryPath.string(), path.string()),
+			                 errno);
+		}
+		syncParentDirectory(path);
+	} catch (...) {
+		// A failure after the rename leaves the final file valid; this unlink is then a no-op.
+		::unlink(temporaryPath.c_str());
+		throw;
+	}
+}
+
+}  // namespace
+
+ChunkserverId parseChunkserverId(std::string_view text) {
+	if (text.size() == kUuidFileSize && text.back() == '\n') { text.remove_suffix(1); }
+	if (text.size() != kUuidTextSize) { throwNotCanonicalUuid(); }
+
+	boost::uuids::uuid uuid;
+	try {
+		uuid = boost::uuids::string_generator{}(text.begin(), text.end());
+	} catch (const std::runtime_error &) { throwNotCanonicalUuid(); }
+
+	if (boost::uuids::to_string(uuid) != text || !isVersion4(uuid)) { throwNotCanonicalUuid(); }
+	return fromBoostUuid(uuid);
+}
+
+std::string formatChunkserverId(const ChunkserverId &chunkserverId) {
+	return boost::uuids::to_string(asBoostUuid(chunkserverId));
+}
+
+ChunkserverId generateChunkserverId() { return fromBoostUuid(boost::uuids::random_generator{}()); }
+
+ChunkserverId loadOrCreateChunkserverId(const std::filesystem::path &path,
+                                        const ChunkserverIdGenerator &generator) {
+	if (const auto existing = readChunkserverId(path)) { return *existing; }
+
+	const ChunkserverId generated = generator();
+	validateGeneratedChunkserverId(generated);
+	persistChunkserverId(path, generated);
+	return generated;
+}
+
+int chunkserverIdInit() {
+	try {
+		if (gChunkserverId) {
+			safs::log_err("chunkserver identity was initialized more than once");
+			return -1;
+		}
+
+		const ChunkserverId resolved = loadOrCreateChunkserverId(
+		    std::filesystem::absolute(kChunkserverIdFilename), generateChunkserverId);
+		gChunkserverId = resolved;
+		safs::log_info("chunkserver identity: {}", formatChunkserverId(resolved));
+		return 0;
+	} catch (const std::exception &exception) {
+		safs::log_err("failed to initialize chunkserver identity: {}", exception.what());
+		return -1;
+	}
+}
+
+const ChunkserverId &chunkserverId() {
+	sassert(gChunkserverId.has_value());
+	return *gChunkserverId;
+}
+
+}  // namespace chunkserver

--- a/src/chunkserver/chunkserver_id.h
+++ b/src/chunkserver/chunkserver_id.h
@@ -1,0 +1,61 @@
+/*
+   Copyright 2026      Leil Storage OÜ
+
+   This file is part of SaunaFS.
+
+   SaunaFS is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, version 3.
+
+   SaunaFS is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with SaunaFS. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "common/platform.h"
+
+#include <array>
+#include <cstdint>
+#include <filesystem>
+#include <functional>
+#include <string>
+#include <string_view>
+
+namespace chunkserver {
+
+using ChunkserverId = std::array<uint8_t, 16>;
+using ChunkserverIdGenerator = std::function<ChunkserverId()>;
+
+inline constexpr const char *kChunkserverIdFilename = "chunkserver_id";
+
+/// Parses a canonical lowercase UUIDv4, with one optional trailing newline.
+///
+/// @throws std::invalid_argument if the text is not a canonical UUIDv4.
+ChunkserverId parseChunkserverId(std::string_view text);
+
+/// Formats an id as a canonical lowercase UUID.
+std::string formatChunkserverId(const ChunkserverId &chunkserverId);
+
+/// Creates a UUIDv4 using a cryptographically strong random generator.
+ChunkserverId generateChunkserverId();
+
+/// Loads an existing id or durably creates one at @p path.
+///
+/// @throws std::exception if existing state is invalid, @p generator fails, or creation cannot be
+/// made durable.
+ChunkserverId loadOrCreateChunkserverId(const std::filesystem::path &path,
+                                        const ChunkserverIdGenerator &generator);
+
+/// Resolves the process identity from the chunkserver data directory.
+int chunkserverIdInit();
+
+/// Returns the identity resolved by @ref chunkserverIdInit.
+const ChunkserverId &chunkserverId();
+
+}  // namespace chunkserver

--- a/src/chunkserver/chunkserver_id_unittest.cc
+++ b/src/chunkserver/chunkserver_id_unittest.cc
@@ -1,0 +1,280 @@
+/*
+   Copyright 2026      Leil Storage OÜ
+
+   This file is part of SaunaFS.
+
+   SaunaFS is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, version 3.
+
+   SaunaFS is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with SaunaFS. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "common/platform.h"
+
+#include <gtest/gtest.h>
+#include <sys/stat.h>
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <filesystem>
+#include <fstream>
+#include <iterator>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "chunkserver/chunkserver_id.h"
+#include "unittests/TemporaryDirectory.h"
+
+namespace chunkserver {
+namespace {
+
+constexpr std::string_view kValidId = "123e4567-e89b-42d3-a456-426614174000";
+constexpr ChunkserverId kValidChunkserverId = {
+    0x12, 0x3e, 0x45, 0x67, 0xe8, 0x9b, 0x42, 0xd3, 0xa4, 0x56, 0x42, 0x66, 0x14, 0x17, 0x40, 0x00,
+};
+
+void writeFile(const std::filesystem::path &path, std::string_view content) {
+	std::ofstream output(path, std::ios::binary);
+	ASSERT_TRUE(output.is_open());
+	output.write(content.data(), static_cast<std::streamsize>(content.size()));
+	ASSERT_TRUE(output.good());
+}
+
+std::string readFile(const std::filesystem::path &path) {
+	std::ifstream input(path, std::ios::binary);
+	return std::string(std::istreambuf_iterator<char>(input), std::istreambuf_iterator<char>());
+}
+
+ChunkserverIdGenerator fixedGenerator(const ChunkserverId &chunkserverId) {
+	return [chunkserverId]() { return chunkserverId; };
+}
+
+TEST(ChunkserverIdTests, ParsesAndFormatsCanonicalVersion4) {
+	const ChunkserverId parsed = parseChunkserverId(kValidId);
+
+	EXPECT_EQ(formatChunkserverId(parsed), kValidId);
+	EXPECT_EQ(parsed[6] & 0xf0, 0x40);
+	EXPECT_EQ(parsed[8] & 0xc0, 0x80);
+}
+
+TEST(ChunkserverIdTests, AcceptsOneTrailingNewline) {
+	EXPECT_EQ(formatChunkserverId(parseChunkserverId(std::string(kValidId) + "\n")), kValidId);
+}
+
+TEST(ChunkserverIdTests, RejectsNoncanonicalOrNonVersion4Text) {
+	const std::vector<std::string> invalidValues = {
+	    "",
+	    "00000000-0000-0000-0000-000000000000",
+	    "-23e4567-e89b-42d3-a456-426614174000",
+	    "123E4567-e89b-42d3-a456-426614174000",
+	    "{123e4567-e89b-42d3-a456-426614174000}",
+	    "123e4567-e89b-12d3-a456-426614174000",
+	    "123e4567-e89b-42d3-7456-426614174000",
+	    "123e4567-e89b-42d3-a456-426614174000 ",
+	    "123e4567-e89b-42d3-a456-426614174000\n\n",
+	    "123e4567-e89b-42d3-a456-42661417400g",
+	    "123e4567e-e89b-42d3-a456-426614174000",
+	};
+
+	for (const std::string &value : invalidValues) {
+		EXPECT_THROW(parseChunkserverId(value), std::invalid_argument) << value;
+	}
+}
+
+TEST(ChunkserverIdTests, RejectsDashInsideLastGroupOfSlicedView) {
+	const std::string longer = "123e4567-e89b-42d3-a456-4266141740-0a";
+	const std::string_view sliced(longer.data(), kValidId.size());
+
+	EXPECT_THROW(parseChunkserverId(sliced), std::invalid_argument);
+}
+
+TEST(ChunkserverIdTests, GeneratesVersion4AndVariantBits) {
+	const ChunkserverId generated = generateChunkserverId();
+
+	EXPECT_EQ(generated[6] & 0xf0, 0x40);
+	EXPECT_EQ(generated[8] & 0xc0, 0x80);
+	EXPECT_EQ(formatChunkserverId(parseChunkserverId(formatChunkserverId(generated))),
+	          formatChunkserverId(generated));
+}
+
+TEST(ChunkserverIdTests, RejectsInvalidGeneratedIdentity) {
+	TemporaryDirectory temporaryDirectory("/tmp", "chunkserver-id-invalid-generator");
+	const std::filesystem::path idPath =
+	    std::filesystem::path(temporaryDirectory.name()) / kChunkserverIdFilename;
+	ChunkserverId wrongVersion = kValidChunkserverId;
+	wrongVersion[6] = static_cast<uint8_t>((wrongVersion[6] & 0x0f) | 0x10);
+	ChunkserverId wrongVariant = kValidChunkserverId;
+	wrongVariant[8] &= 0x3f;
+	const std::vector<ChunkserverId> invalidIds = {ChunkserverId{}, wrongVersion, wrongVariant};
+
+	for (const ChunkserverId &invalidId : invalidIds) {
+		EXPECT_THROW(loadOrCreateChunkserverId(idPath, fixedGenerator(invalidId)),
+		             std::runtime_error);
+	}
+	EXPECT_FALSE(std::filesystem::exists(idPath));
+	EXPECT_FALSE(std::filesystem::exists(idPath.string() + ".tmp"));
+}
+
+TEST(ChunkserverIdTests, PropagatesGeneratorFailure) {
+	TemporaryDirectory temporaryDirectory("/tmp", "chunkserver-id-generator-failure");
+	const std::filesystem::path idPath =
+	    std::filesystem::path(temporaryDirectory.name()) / kChunkserverIdFilename;
+	const auto failingGenerator = []() -> ChunkserverId {
+		throw std::runtime_error("injected generator failure");
+	};
+
+	EXPECT_THROW(loadOrCreateChunkserverId(idPath, failingGenerator), std::runtime_error);
+	EXPECT_FALSE(std::filesystem::exists(idPath));
+	EXPECT_FALSE(std::filesystem::exists(idPath.string() + ".tmp"));
+}
+
+TEST(ChunkserverIdTests, CreatesThenReusesIdentityWithoutRewriting) {
+	TemporaryDirectory temporaryDirectory("/tmp", "chunkserver-id-reuse");
+	const std::filesystem::path idPath =
+	    std::filesystem::path(temporaryDirectory.name()) / kChunkserverIdFilename;
+	const ChunkserverId created =
+	    loadOrCreateChunkserverId(idPath, fixedGenerator(kValidChunkserverId));
+	struct stat beforeStatus {};
+	ASSERT_EQ(::stat(idPath.c_str(), &beforeStatus), 0);
+
+	bool generatorCalled = false;
+	const ChunkserverId reused = loadOrCreateChunkserverId(idPath, [&generatorCalled]() {
+		generatorCalled = true;
+		return kValidChunkserverId;
+	});
+	struct stat afterStatus {};
+	ASSERT_EQ(::stat(idPath.c_str(), &afterStatus), 0);
+
+	EXPECT_EQ(reused, created);
+	EXPECT_FALSE(generatorCalled);
+	EXPECT_EQ(afterStatus.st_ino, beforeStatus.st_ino);
+	EXPECT_EQ(readFile(idPath), formatChunkserverId(created) + "\n");
+	EXPECT_FALSE(std::filesystem::exists(idPath.string() + ".tmp"));
+}
+
+TEST(ChunkserverIdTests, ReplacesStaleTemporaryFile) {
+	TemporaryDirectory temporaryDirectory("/tmp", "chunkserver-id-stale-temp");
+	const std::filesystem::path idPath =
+	    std::filesystem::path(temporaryDirectory.name()) / kChunkserverIdFilename;
+	writeFile(idPath.string() + ".tmp", "incomplete");
+
+	const ChunkserverId created =
+	    loadOrCreateChunkserverId(idPath, fixedGenerator(kValidChunkserverId));
+
+	EXPECT_EQ(readFile(idPath), formatChunkserverId(created) + "\n");
+	EXPECT_FALSE(std::filesystem::exists(idPath.string() + ".tmp"));
+}
+
+TEST(ChunkserverIdTests, RejectsInvalidExistingFileWithoutReplacingIt) {
+	TemporaryDirectory temporaryDirectory("/tmp", "chunkserver-id-invalid");
+	const std::filesystem::path idPath =
+	    std::filesystem::path(temporaryDirectory.name()) / kChunkserverIdFilename;
+	const std::string invalidContent = "123E4567-e89b-42d3-a456-426614174000\n";
+	writeFile(idPath, invalidContent);
+	bool generatorCalled = false;
+
+	EXPECT_THROW(loadOrCreateChunkserverId(idPath,
+	                                       [&generatorCalled]() {
+		                                       generatorCalled = true;
+		                                       return kValidChunkserverId;
+	                                       }),
+	             std::invalid_argument);
+	EXPECT_FALSE(generatorCalled);
+	EXPECT_EQ(readFile(idPath), invalidContent);
+}
+
+TEST(ChunkserverIdTests, AcceptsExistingFileWithoutTrailingNewline) {
+	TemporaryDirectory temporaryDirectory("/tmp", "chunkserver-id-no-newline");
+	const std::filesystem::path idPath =
+	    std::filesystem::path(temporaryDirectory.name()) / kChunkserverIdFilename;
+	writeFile(idPath, kValidId);
+	bool generatorCalled = false;
+
+	const ChunkserverId loaded = loadOrCreateChunkserverId(idPath, [&generatorCalled]() {
+		generatorCalled = true;
+		return kValidChunkserverId;
+	});
+
+	EXPECT_EQ(formatChunkserverId(loaded), kValidId);
+	EXPECT_FALSE(generatorCalled);
+	EXPECT_EQ(readFile(idPath), kValidId);
+}
+
+TEST(ChunkserverIdTests, RejectsExistingFileOfUnexpectedSize) {
+	TemporaryDirectory temporaryDirectory("/tmp", "chunkserver-id-wrong-size");
+	const std::filesystem::path idPath =
+	    std::filesystem::path(temporaryDirectory.name()) / kChunkserverIdFilename;
+	const std::vector<std::string> contents = {"", std::string(kValidId) + "\n\n"};
+
+	for (const std::string &content : contents) {
+		writeFile(idPath, content);
+		EXPECT_THROW(loadOrCreateChunkserverId(idPath, fixedGenerator(kValidChunkserverId)),
+		             std::runtime_error)
+		    << content.size();
+		EXPECT_EQ(readFile(idPath), content);
+	}
+}
+
+TEST(ChunkserverIdTests, RejectsNonRegularExistingPath) {
+	TemporaryDirectory temporaryDirectory("/tmp", "chunkserver-id-directory");
+	const std::filesystem::path idPath =
+	    std::filesystem::path(temporaryDirectory.name()) / kChunkserverIdFilename;
+	ASSERT_TRUE(std::filesystem::create_directory(idPath));
+
+	EXPECT_THROW(loadOrCreateChunkserverId(idPath, fixedGenerator(kValidChunkserverId)),
+	             std::runtime_error);
+	EXPECT_TRUE(std::filesystem::is_directory(idPath));
+}
+
+TEST(ChunkserverIdTests, RejectsDanglingSymlinkWithoutReplacingIt) {
+	TemporaryDirectory temporaryDirectory("/tmp", "chunkserver-id-symlink");
+	const std::filesystem::path idPath =
+	    std::filesystem::path(temporaryDirectory.name()) / kChunkserverIdFilename;
+	std::filesystem::create_symlink("missing-target", idPath);
+	ASSERT_TRUE(std::filesystem::is_symlink(idPath));
+	bool generatorCalled = false;
+
+	EXPECT_THROW(loadOrCreateChunkserverId(idPath,
+	                                       [&generatorCalled]() {
+		                                       generatorCalled = true;
+		                                       return kValidChunkserverId;
+	                                       }),
+	             std::system_error);
+	EXPECT_FALSE(generatorCalled);
+	EXPECT_TRUE(std::filesystem::is_symlink(idPath));
+}
+
+TEST(ChunkserverIdTests, RejectsFifoWithoutBlocking) {
+	TemporaryDirectory temporaryDirectory("/tmp", "chunkserver-id-fifo");
+	const std::filesystem::path idPath =
+	    std::filesystem::path(temporaryDirectory.name()) / kChunkserverIdFilename;
+	ASSERT_EQ(::mkfifo(idPath.c_str(), S_IRUSR | S_IWUSR), 0);
+
+	EXPECT_THROW(loadOrCreateChunkserverId(idPath, fixedGenerator(kValidChunkserverId)),
+	             std::runtime_error);
+}
+
+TEST(ChunkserverIdTests, FailsIfStaleTemporaryPathCannotBeRemoved) {
+	TemporaryDirectory temporaryDirectory("/tmp", "chunkserver-id-blocked-temp");
+	const std::filesystem::path idPath =
+	    std::filesystem::path(temporaryDirectory.name()) / kChunkserverIdFilename;
+	const std::filesystem::path temporaryPath = idPath.string() + ".tmp";
+	ASSERT_TRUE(std::filesystem::create_directory(temporaryPath));
+
+	EXPECT_THROW(loadOrCreateChunkserverId(idPath, fixedGenerator(kValidChunkserverId)),
+	             std::system_error);
+	EXPECT_FALSE(std::filesystem::exists(idPath));
+	EXPECT_TRUE(std::filesystem::is_directory(temporaryPath));
+}
+
+}  // namespace
+}  // namespace chunkserver

--- a/src/chunkserver/init.h
+++ b/src/chunkserver/init.h
@@ -24,6 +24,7 @@
 
 #include "chunkserver-common/memory_manager.h"
 #include "chunkserver/chartsdata.h"
+#include "chunkserver/chunkserver_id.h"
 #include "chunkserver/hddspacemgr.h"
 #include "chunkserver/masterconn.h"
 #include "chunkserver/network_main_thread.h"
@@ -35,6 +36,7 @@ inline const std::vector<RunTab> earlyRunTabs = {};
 
 /// Functions to call during normal startup
 inline const std::vector<RunTab> runTabs = {
+    RunTab{.function = chunkserver::chunkserverIdInit, .name = "chunkserver identity"},
     RunTab{.function = rnd_init, .name = "random generator"},
     RunTab{.function = MemoryManager::init, .name = "memory manager"},
     RunTab{.function = initDiskManager, .name = "disk manager"},  // Always before "plugin manager"

--- a/src/common/cwrap.cc
+++ b/src/common/cwrap.cc
@@ -54,6 +54,12 @@ void FileDescriptor::reset(int fd) {
 	fd_ = fd;
 }
 
+int FileDescriptor::release() {
+	const int fd = fd_;
+	fd_ = -1;
+	return fd;
+}
+
 void FileDescriptor::close() {
 	massert(fd_ >= 0, "file descriptor is not opened");
 	::close(fd_);

--- a/src/common/cwrap.h
+++ b/src/common/cwrap.h
@@ -38,6 +38,8 @@ public:
 	int get() const;
 	void reset(int fd);
 	void close();
+	/// Gives up ownership without closing; returns the descriptor (-1 if none).
+	int release();
 	bool isOpened() const;
 
 private:

--- a/tests/test_suites/SanityChecks/test_chunkserver_stable_identity.sh
+++ b/tests/test_suites/SanityChecks/test_chunkserver_stable_identity.sh
@@ -1,0 +1,70 @@
+timeout_set 120 seconds
+
+uuid_pattern='^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$'
+chunkserver_log="${TEMP_DIR}/chunkserver.log"
+
+CHUNKSERVERS=2 \
+	USE_RAMDISK=YES \
+	MOUNT_EXTRA_CONFIG="sfscachemode=NEVER" \
+	CHUNKSERVER_EXTRA_CONFIG="MAGIC_DEBUG_LOG=${chunkserver_log}|LOG_FLUSH_ON=INFO" \
+	setup_local_empty_saunafs info
+
+chunkserver0_data_path=$(sed -n 's/^DATA_PATH = //p' "${info[chunkserver0_cfg]}")
+chunkserver1_data_path=$(sed -n 's/^DATA_PATH = //p' "${info[chunkserver1_cfg]}")
+chunkserver0_id_file="${chunkserver0_data_path}/chunkserver_id"
+chunkserver1_id_file="${chunkserver1_data_path}/chunkserver_id"
+
+assert_file_exists "${chunkserver0_id_file}"
+assert_file_exists "${chunkserver1_id_file}"
+
+chunkserver0_id=$(<"${chunkserver0_id_file}")
+chunkserver1_id=$(<"${chunkserver1_id_file}")
+assert_matches "${uuid_pattern}" "${chunkserver0_id}"
+assert_matches "${uuid_pattern}" "${chunkserver1_id}"
+assert_not_equal "${chunkserver0_id}" "${chunkserver1_id}"
+
+cd "${info[mount0]}"
+FILE_SIZE=1M file-generate file
+file-validate file
+
+saunafs_chunkserver_daemon 0 restart
+saunafs_wait_for_all_ready_chunkservers
+
+assert_equals "${chunkserver0_id}" "$(<"${chunkserver0_id_file}")"
+# Both starts of chunkserver 0 must have logged the same identity.
+assert_equals 2 "$(grep -cF "chunkserver identity: ${chunkserver0_id}" "${chunkserver_log}")"
+file-validate file
+
+previous_chunkserver0_id="${chunkserver0_id}"
+
+# Commands which do not start the service must not create an identity.
+saunafs_chunkserver_daemon 0 stop
+rm "${chunkserver0_id_file}"
+assert_success saunafs_chunkserver_daemon 0 test
+assert_failure saunafs_chunkserver_daemon 0 isalive
+assert_file_not_exists "${chunkserver0_id_file}"
+
+saunafs_chunkserver_daemon 0 start
+saunafs_wait_for_all_ready_chunkservers
+chunkserver0_id=$(<"${chunkserver0_id_file}")
+assert_matches "${uuid_pattern}" "${chunkserver0_id}"
+assert_not_equal "${previous_chunkserver0_id}" "${chunkserver0_id}"
+
+# An invalid identity must stop startup without silently replacing the file.
+saunafs_chunkserver_daemon 0 stop
+printf 'invalid\n' >"${chunkserver0_id_file}"
+assert_failure saunafs_chunkserver_daemon 0 start
+assert_equals invalid "$(<"${chunkserver0_id_file}")"
+
+# Failure to persist a new identity must stop startup.
+rm "${chunkserver0_id_file}"
+mkdir "${chunkserver0_id_file}.tmp"
+assert_failure saunafs_chunkserver_daemon 0 start
+assert_file_not_exists "${chunkserver0_id_file}"
+assert_success test -d "${chunkserver0_id_file}.tmp"
+rmdir "${chunkserver0_id_file}.tmp"
+
+printf '%s\n' "${chunkserver0_id}" >"${chunkserver0_id_file}"
+saunafs_chunkserver_daemon 0 start
+saunafs_wait_for_all_ready_chunkservers
+file-validate file

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -6,6 +6,7 @@
     "boost-iostreams",
     "boost-program-options",
     "boost-system",
+    "boost-uuid",
     "bzip2",
     "fmt",
     "gtest",
@@ -269,6 +270,10 @@
     },
     {
       "name": "boost-utility",
+      "version": "1.86.0"
+    },
+    {
+      "name": "boost-uuid",
       "version": "1.86.0"
     },
     {


### PR DESCRIPTION
Give each chunkserver a durable identity that survives restarts. Future
coordination can then recognize the same storage node without relying on
its network address.

Create and sync the identity atomically in the data directory. Refuse to
start if an existing identity is malformed or cannot be read safely.

Use Boost.UUID for generation, parsing, and formatting. Boost.UUID is
header only and supports the older Boost versions accepted by the
project's system-package builds. Reuse the existing `FileDescriptor`
wrapper, with explicit checked closes where persistence errors matter.

Add unit and system coverage for initial creation, restart persistence,
independent installations, invalid state, and non-daemon commands.

This change only creates the local identity. It does not advertise the
UUID, change registration packets, or alter Master behavior.

Related to: LS-1063