### PR TITLE
refactor(cs): generalize the disk plugin hooks

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -83,7 +83,7 @@ automate the build process. Please, follow the instructions below to build LeilF
 ### Dependencies needed to build deb packages
 
 ```text
-acl asciidoc attr bc build-essential ca-certificates-java ccache cmake curl debhelper devscripts fuse3 git libblkid-dev libboost-filesystem-dev libboost-iostreams-dev libboost-program-options-dev libboost-system-dev libcrcutil-dev libdb-dev libfmt-dev libfuse3-dev libgoogle-perftools-dev libgtest-dev libisal-dev libjudy-dev libpam0g-dev libspdlog-dev libssl-dev libsystemd-dev liburcu-dev libyaml-cpp-dev lsb-release netcat-openbsd nfs4-acl-tools pkg-config pylint python3 python3-pip rsync socat sudo tidy time uuid-dev valgrind wget zlib1g-dev
+acl asciidoc attr bc build-essential ca-certificates-java ccache cmake curl debhelper devscripts fuse3 git libblkid-dev libboost-filesystem-dev libboost-iostreams-dev libboost-program-options-dev libboost-system-dev libcrcutil-dev libdb-dev libfmt-dev libfuse3-dev libgoogle-perftools-dev libgtest-dev libisal-dev libjudy-dev libpam0g-dev libspdlog-dev libssl-dev libsystemd-dev liburcu-dev libyaml-cpp-dev libzstd-dev lsb-release netcat-openbsd nfs4-acl-tools pkg-config pylint python3 python3-pip rsync socat sudo tidy time uuid-dev valgrind wget zlib1g-dev
 ```
 
 The following scripts can be used to install the dependencies on Ubuntu 24.04 (Noble):

--- a/cmake/Libraries.cmake
+++ b/cmake/Libraries.cmake
@@ -59,6 +59,42 @@ else()
   message(STATUS "   to point this path (cmake -DZLIB_ROOT=...)")
 endif()
 
+# Find Zstandard, used for per-block chunk compression in the chunkserver.
+# CONFIG mode covers vcpkg; distribution packages often ship only pkg-config.
+find_package(zstd CONFIG QUIET)
+
+if(TARGET zstd::libzstd_shared)
+  set(ZSTD_LIBRARIES zstd::libzstd_shared)
+elseif(TARGET zstd::libzstd_static)
+  set(ZSTD_LIBRARIES zstd::libzstd_static)
+elseif(TARGET zstd::libzstd)
+  set(ZSTD_LIBRARIES zstd::libzstd)
+else()
+  find_package(PkgConfig QUIET)
+  if(PKG_CONFIG_FOUND)
+    pkg_check_modules(ZSTD_PC QUIET IMPORTED_TARGET libzstd)
+  endif()
+
+  if(TARGET PkgConfig::ZSTD_PC)
+    set(ZSTD_LIBRARIES PkgConfig::ZSTD_PC)
+  else()
+    find_library(ZSTD_LIBRARY NAMES zstd)
+    find_path(ZSTD_INCLUDE_DIR NAMES zstd.h)
+
+    if(NOT ZSTD_LIBRARY OR NOT ZSTD_INCLUDE_DIR)
+      message(FATAL_ERROR "Could not find Zstandard (required). "
+              "Install libzstd-dev (Debian) or libzstd-devel (Fedora).")
+    endif()
+
+    add_library(zstd::libzstd UNKNOWN IMPORTED)
+    set_target_properties(zstd::libzstd PROPERTIES
+      IMPORTED_LOCATION "${ZSTD_LIBRARY}"
+      INTERFACE_INCLUDE_DIRECTORIES "${ZSTD_INCLUDE_DIR}")
+    set(ZSTD_LIBRARIES zstd::libzstd)
+  endif()
+endif()
+message(STATUS "ZSTD LIBRARY: ${ZSTD_LIBRARIES}")
+
 # Find Systemd
 INCLUDE(FindPkgConfig)
 pkg_check_modules(SYSTEMD libsystemd)

--- a/doc/leil-hdd.cfg.5.adoc
+++ b/doc/leil-hdd.cfg.5.adoc
@@ -24,10 +24,31 @@ even in a separate drive, by splitting both paths using ' | ':
 This way, the metadata parts can be stored, for instance, in NVMe and the data
 parts in HDD.
 
+=== STORAGE PLUGIN PREFIXES
+
+A directory may be served by a chunkserver storage plugin rather than by the
+built-in one. Name the plugin at the start of the line, followed by a colon:
+
+----
+[*]<plugin>:/path/to/metadata[ | /path/to/data]
+----
+
+The plugin name may contain letters, digits and underscores, and the colon must
+follow it immediately. An absolute path is therefore never read as a prefix,
+since the leading `/` cannot appear in a plugin name. A *relative* path is
+ambiguous when its first component is made only of those characters and
+contains a colon, as in `archive:01`; write it as `./archive:01` to have it
+read as a path.
+
+A line naming a plugin that is not installed is rejected: the error is logged,
+the rest of the file is not read, and the chunkserver continues with the disks
+configured by the lines above it. Whether the two-path form is required depends
+on the plugin.
+
 === HOST-MANAGED SMR SPECIFICS
 
-With the proprietary chunkserver plugin for Host-Managed SMR drives, use the
-`zonefs:` prefix with the following syntax:
+The proprietary chunkserver plugin for Host-Managed SMR drives answers to the
+`zonefs:` prefix, and always requires the two-path form:
 
 ----
 [*]zonefs:/path/to/metadata | /path/to/data

--- a/rpm/leilfs.spec
+++ b/rpm/leilfs.spec
@@ -37,6 +37,7 @@ BuildRequires:  fmt-devel
 BuildRequires:  fuse3-devel
 BuildRequires:  isa-l-devel
 BuildRequires:  Judy-devel
+BuildRequires:  libzstd-devel
 BuildRequires:  openssl-devel
 BuildRequires:  pam-devel
 BuildRequires:  spdlog-devel

--- a/src/chunkserver/chunkserver-common/CMakeLists.txt
+++ b/src/chunkserver/chunkserver-common/CMakeLists.txt
@@ -6,7 +6,8 @@ shared_target_link_libraries(chunkserver-common
         safsprotocol
         leil-common
         ${Boost_LIBRARIES}
-        ${ADDITIONAL_LIBS})
+        ${ADDITIONAL_LIBS}
+        ${ZSTD_LIBRARIES})
 
 shared_target_link_libraries(chunkserver-common STATIC sfserr SHARED sfserr_pic)
 

--- a/src/chunkserver/chunkserver-common/block_compression.cc
+++ b/src/chunkserver/chunkserver-common/block_compression.cc
@@ -1,0 +1,95 @@
+/*
+   Copyright 2026 Leil Storage
+
+   This file is part of SaunaFS.
+
+   SaunaFS is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, version 3.
+
+   SaunaFS is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with SaunaFS. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "common/platform.h"
+
+#include "chunkserver-common/block_compression.h"
+
+#include <zstd.h>
+
+namespace block_compression {
+
+namespace {
+
+struct CCtxDeleter {
+	void operator()(ZSTD_CCtx *cctx) const { ZSTD_freeCCtx(cctx); }
+};
+struct DCtxDeleter {
+	void operator()(ZSTD_DCtx *dctx) const { ZSTD_freeDCtx(dctx); }
+};
+
+// One reusable compression/decompression context per thread, to avoid
+// per-block allocation.
+ZSTD_CCtx *threadLocalCCtx() {
+	static thread_local std::unique_ptr<ZSTD_CCtx, CCtxDeleter> cctx(ZSTD_createCCtx());
+	return cctx.get();
+}
+
+ZSTD_DCtx *threadLocalDCtx() {
+	static thread_local std::unique_ptr<ZSTD_DCtx, DCtxDeleter> dctx(ZSTD_createDCtx());
+	return dctx.get();
+}
+
+}  // namespace
+
+void CDictDeleter::operator()(ZSTD_CDict *cdict) const { ZSTD_freeCDict(cdict); }
+
+void DDictDeleter::operator()(ZSTD_DDict *ddict) const { ZSTD_freeDDict(ddict); }
+
+CDictPtr createCDict(const uint8_t *dict, size_t dictSize, int level) {
+	if (dict == nullptr || dictSize == 0) { return nullptr; }
+	// Auto-detects trained vs raw-content, and copies the bytes.
+	return CDictPtr(ZSTD_createCDict(dict, dictSize, level));
+}
+
+DDictPtr createDDict(const uint8_t *dict, size_t dictSize) {
+	if (dict == nullptr || dictSize == 0) { return nullptr; }
+	return DDictPtr(ZSTD_createDDict(dict, dictSize));
+}
+
+ssize_t compressBlock(const ZSTD_CDict *cdict, const uint8_t *src, size_t srcSize, uint8_t *dst,
+                      size_t dstCapacity, int level) {
+	ZSTD_CCtx *cctx = threadLocalCCtx();
+	if (cctx == nullptr) { return -1; }
+
+	const size_t result =
+	    cdict != nullptr ? ZSTD_compress_usingCDict(cctx, dst, dstCapacity, src, srcSize, cdict)
+	                     : ZSTD_compressCCtx(cctx, dst, dstCapacity, src, srcSize, level);
+
+	if (ZSTD_isError(result)) { return -1; }
+
+	return static_cast<ssize_t>(result);
+}
+
+ssize_t decompressBlock(const ZSTD_DDict *ddict, const uint8_t *src, size_t srcSize, uint8_t *dst,
+                        size_t dstCapacity) {
+	ZSTD_DCtx *dctx = threadLocalDCtx();
+	if (dctx == nullptr) { return -1; }
+
+	const size_t result =
+	    ddict != nullptr ? ZSTD_decompress_usingDDict(dctx, dst, dstCapacity, src, srcSize, ddict)
+	                     : ZSTD_decompressDCtx(dctx, dst, dstCapacity, src, srcSize);
+
+	if (ZSTD_isError(result)) { return -1; }
+
+	return static_cast<ssize_t>(result);
+}
+
+size_t compressBound(size_t srcSize) { return ZSTD_compressBound(srcSize); }
+
+}  // namespace block_compression

--- a/src/chunkserver/chunkserver-common/block_compression.h
+++ b/src/chunkserver/chunkserver-common/block_compression.h
@@ -1,0 +1,75 @@
+/*
+   Copyright 2026 Leil Storage
+
+   This file is part of SaunaFS.
+
+   SaunaFS is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, version 3.
+
+   SaunaFS is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with SaunaFS. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "common/platform.h"
+
+#include <sys/types.h>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+
+// Opaque digested-dictionary types, forward-declared exactly as <zstd.h> does
+// so this header does not drag the zstd headers into every includer.
+typedef struct ZSTD_CDict_s ZSTD_CDict;
+typedef struct ZSTD_DDict_s ZSTD_DDict;
+
+/// Shared wrapper isolating Zstandard usage, so the compressed on-disk formats
+/// stay byte compatible across disk plugins.
+///
+/// One frame per SFSBLOCKSIZE block, so a random read decompresses only the
+/// block it asked for. A chunk's frames share one immutable dictionary,
+/// digested once per chunk because digesting costs more than a block does.
+namespace block_compression {
+
+/// Deleters, so the opaque types above can still be held in unique_ptr.
+struct CDictDeleter {
+	void operator()(ZSTD_CDict *cdict) const;
+};
+struct DDictDeleter {
+	void operator()(ZSTD_DDict *ddict) const;
+};
+
+using CDictPtr = std::unique_ptr<ZSTD_CDict, CDictDeleter>;
+using DDictPtr = std::unique_ptr<ZSTD_DDict, DDictDeleter>;
+
+/// Digests dictionary bytes for compression at @p level, auto-detecting trained
+/// vs raw-content. nullptr if empty or on failure - compress without one.
+CDictPtr createCDict(const uint8_t *dict, size_t dictSize, int level);
+
+/// Digests dictionary bytes for decompression; nullptr if empty or on failure.
+DDictPtr createDDict(const uint8_t *dict, size_t dictSize);
+
+/// Compresses one block into @p dst, using @p cdict or nullptr for none - in
+/// which case @p level applies instead.
+///
+/// @return the compressed size, or negative on error. A size >= srcSize means
+///         the caller should store the block raw.
+ssize_t compressBlock(const ZSTD_CDict *cdict, const uint8_t *src, size_t srcSize, uint8_t *dst,
+                      size_t dstCapacity, int level);
+
+/// Decompresses one block produced by compressBlock() with the same dictionary.
+/// @return the decompressed size, or negative on error.
+ssize_t decompressBlock(const ZSTD_DDict *ddict, const uint8_t *src, size_t srcSize, uint8_t *dst,
+                        size_t dstCapacity);
+
+/// Upper bound on the compressed size of a block of srcSize bytes.
+size_t compressBound(size_t srcSize);
+
+}  // namespace block_compression

--- a/src/chunkserver/chunkserver-common/default_disk_manager.cc
+++ b/src/chunkserver/chunkserver-common/default_disk_manager.cc
@@ -42,17 +42,32 @@ int DefaultDiskManager::parseCfgLine(std::string hddCfgLine) {
 		                          hddCfgLine);
 	}
 
+	// Disks are matched by path on reload, and a Disk does not remember which
+	// plugin made it, so a changed prefix would silently keep the old one.
+	const auto knownPrefix = diskPrefixes_.find(configuration.metaPath);
+
+	if (knownPrefix != diskPrefixes_.end() &&
+	    knownPrefix->second != configuration.prefix) {
+		throw InitializeException(
+		    "Disk plugin has changed between reloads for line: " + hddCfgLine);
+	}
+
 	IDisk *currentDisk = DiskNotFound;
 
-	if (configuration.isZoned) {
+	// The prefix names the plugin owning the Disk; no prefix is a plain CmrDisk.
+	if (!configuration.prefix.empty()) {
 		currentDisk = pluginManager.createDisk(configuration);
 	} else {
 		currentDisk = new CmrDisk(configuration);
 	}
 
 	if (currentDisk == DiskNotFound) {
-		throw InitializeException("HDD configuration line not valid: " +
-		                          hddCfgLine);
+		// The line parsed, so say which plugin is missing rather than blaming
+		// its syntax.
+		throw InitializeException(
+		    "No Disk plugin loaded for prefix '" + configuration.prefix +
+		    "' (loaded: " + pluginManager.loadedDiskPrefixes() +
+		    ") in line: " + hddCfgLine);
 	}
 
 	{
@@ -91,6 +106,10 @@ int DefaultDiskManager::parseCfgLine(std::string hddCfgLine) {
 		delete currentDisk;
 		throw InitializeException(ie.what());
 	}
+
+	// Recorded only now: a line that threw above was never configured, so a
+	// corrected retry must not be read as a change of plugin.
+	diskPrefixes_[configuration.metaPath] = configuration.prefix;
 
 	std::unique_lock disksUniqueLock(gDisksMutex);
 

--- a/src/chunkserver/chunkserver-common/default_disk_manager.cc
+++ b/src/chunkserver/chunkserver-common/default_disk_manager.cc
@@ -202,8 +202,27 @@ void DefaultDiskManager::reloadDisksFromCfg() {
 	}
 
 	std::string line;
-	while (std::getline(hddFile, line)) {
-		parseCfgLine(std::move(line));
+
+	try {
+		while (std::getline(hddFile, line)) {
+			parseCfgLine(std::move(line));
+		}
+	} catch (...) {
+		// The pass never reached the lines below the failing one, so their
+		// Disks are still marked as gone. Clear the marks before anything acts
+		// on them and let disk actions resume: the reload failed, so the
+		// previous configuration stands.
+		{
+			std::lock_guard disksLockGuard(gDisksMutex);
+
+			for (auto &disk : gDisks) {
+				disk->setWasRemovedFromConfig(false);
+			}
+
+			gDiskActions = 1;
+		}
+
+		throw;
 	}
 
 	hddFile.close();

--- a/src/chunkserver/chunkserver-common/default_disk_manager.h
+++ b/src/chunkserver/chunkserver-common/default_disk_manager.h
@@ -20,6 +20,9 @@
 
 #include "common/platform.h"
 
+#include <map>
+#include <string>
+
 #include "chunkserver-common/disk_manager_interface.h"
 #include "chunkserver-common/global_shared_resources.h"
 
@@ -86,6 +89,9 @@ public:
 	void resetDiskIteratorForTests() override;
 
 private:
+	/// Plugin prefix each metadata path was last configured with.
+	std::map<std::string, std::string> diskPrefixes_;
+
 	/// Next disk index for GC. Helps in the round-robin strategy.
 	uint32_t nextDiskIndexForGC_ = 0;
 

--- a/src/chunkserver/chunkserver-common/disk_interface.h
+++ b/src/chunkserver/chunkserver-common/disk_interface.h
@@ -30,6 +30,9 @@ constexpr IDisk* DiskNotFound = nullptr;
 
 class IChunk;
 
+/// Shared with dlopen'ed Disk plugins, so changing it breaks every plugin
+/// built against an older revision of the same release.
+///
 /// Represents a data disk in the Chunkserver context.
 ///
 /// Each Disk maps to a single line in the hdd.cfg file.
@@ -84,6 +87,15 @@ public:
 	/// Tells if this Disk is a Zoned device. A Zoned device is the one that
 	/// have their address space divided into zones, for instance SMR drives.
 	virtual bool isZonedDevice() const = 0;
+
+	/// Tells if block N of a Chunk on this Disk lives at N * SFSBLOCKSIZE in
+	/// the data file.
+	///
+	/// When true, the caller may compute data-file offsets itself, truncate the
+	/// data file to a logical length and append raw bytes with writeChunkData().
+	/// When false the Disk owns its own data layout, so every access must go
+	/// through the block-level API (writeChunkBlock/writeChunkBlocks/preadData).
+	virtual bool hasImplicitBlockOffsets() const = 0;
 
 	/// Tells if this Disk is suitable for storing new chunks, according to its
 	/// general state (available space, not readonly, etc.).

--- a/src/chunkserver/chunkserver-common/disk_plugin.h
+++ b/src/chunkserver/chunkserver-common/disk_plugin.h
@@ -45,10 +45,13 @@ public:
 	/// Override this method if you need to change the version for testing.
 	unsigned int version() override { return SAUNAFS_VERSHEX; }
 
-	/// Returns the disk prefix handled by this plugin.
-	/// For instance, to handle the following hdd.conf line:
+	/// Returns the disk prefix handled by this plugin, the part of an hdd.cfg
+	/// line before the ':'. For instance, a plugin returning 'zonefs' handles
 	/// zonefs:/mnt/saunafs/meta/nvme1 | /mnt/saunafs/data/smr1
-	/// the prefix must be 'zonefs'.
+	///
+	/// Only letters, digits and '_' are accepted (disk::kDiskPrefixCharacters),
+	/// and the prefix must be free: a plugin offering anything else, or one
+	/// already claimed, is ignored at load time rather than registered.
 	virtual std::string prefix() = 0;
 
 	/// Returns a newly created concrete Disk with the given configuration.

--- a/src/chunkserver/chunkserver-common/disk_utils.cc
+++ b/src/chunkserver/chunkserver-common/disk_utils.cc
@@ -57,11 +57,20 @@ Configuration::Configuration(std::string hddCfgLine) {
 		hddCfgLine.erase(hddCfgLine.begin());
 	}
 
-	static const std::string zonedToken = "zonefs:";
-	if (hddCfgLine.find(zonedToken) == 0) {
-		prefix = hddCfgLine.substr(0, zonedToken.size() - 1);
-		isZoned = true;
-		hddCfgLine.erase(0, zonedToken.size());
+	// A leading "<prefix>:" selects the Disk plugin owning this device; a bare
+	// path has no prefix and is served by the built-in CmrDisk.
+	const auto prefixEnd = hddCfgLine.find_first_not_of(kDiskPrefixCharacters);
+
+	if (prefixEnd != std::string::npos && prefixEnd > 0 &&
+	    hddCfgLine.at(prefixEnd) == ':') {
+		prefix = hddCfgLine.substr(0, prefixEnd);
+		isZoned = (prefix == kZonedDiskPrefix);
+		hddCfgLine.erase(0, prefixEnd + 1);
+	}
+
+	if (hddCfgLine.empty()) {  // Nothing left once the markers are removed
+		isValid = false;
+		return;
 	}
 
 	static std::string const delimiter = " | ";
@@ -82,6 +91,11 @@ Configuration::Configuration(std::string hddCfgLine) {
 	} else {
 		metaPath = hddCfgLine;
 		dataPath = hddCfgLine;
+	}
+
+	if (metaPath.empty() || dataPath.empty()) {  // e.g. "prefix: | /data"
+		isValid = false;
+		return;
 	}
 
 	// Ensure / at the end for both paths

--- a/src/chunkserver/chunkserver-common/disk_utils.h
+++ b/src/chunkserver/chunkserver-common/disk_utils.h
@@ -48,6 +48,16 @@ static constexpr size_t kScanInProgressFlagIndex = 2;
 
 static constexpr mode_t kDefaultOpenMode = 0666;
 
+/// Characters allowed in an hdd.cfg "<prefix>:" plugin selector. Excludes '/'
+/// and '.', so an absolute path, or a relative one written "./", is never
+/// parsed as a prefix.
+constexpr char kDiskPrefixCharacters[] =
+    "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_";
+
+/// The only prefix denoting a zoned device; every other plugin serves a
+/// conventional one.
+constexpr char kZonedDiskPrefix[] = "zonefs";
+
 /// Possible modes to call the `hddChunkFindOrCreatePlusLock` function.
 enum class ChunkGetMode {
 	kFindOnly,      ///< Do not create any new Chunk, just look for existing.

--- a/src/chunkserver/chunkserver-common/disk_with_fd.cc
+++ b/src/chunkserver/chunkserver-common/disk_with_fd.cc
@@ -59,6 +59,11 @@ bool FDDisk::isMarkedForDeletion() const {
 
 bool FDDisk::isZonedDevice() const { return isZonedDevice_; }
 
+// Sequential zones are written at a moving write head, so a zoned Disk maps
+// blocks itself. Every other Disk keeps the plain block N -> N * SFSBLOCKSIZE
+// layout unless it overrides this.
+bool FDDisk::hasImplicitBlockOffsets() const { return !isZonedDevice_; }
+
 bool FDDisk::isSelectableForNewChunk() const {
 	return !isDamaged_ && !isMarkedForDeletion() && !wasRemovedFromConfig_ && totalSpace_ != 0 &&
 	       availableSpace_ != 0 && scanState_ == IDisk::ScanState::kWorking;

--- a/src/chunkserver/chunkserver-common/disk_with_fd.h
+++ b/src/chunkserver/chunkserver-common/disk_with_fd.h
@@ -65,6 +65,9 @@ public:
 	/// Tells if this Disk is a Zoned device
 	bool isZonedDevice() const override;
 
+	/// Tells if block N lives at N * SFSBLOCKSIZE in the data file
+	bool hasImplicitBlockOffsets() const override;
+
 	/// Tells if this Disk is suitable for storing new chunks,
 	/// according to its general state
 	bool isSelectableForNewChunk() const override;

--- a/src/chunkserver/chunkserver-common/plugin_manager.cc
+++ b/src/chunkserver/chunkserver-common/plugin_manager.cc
@@ -23,7 +23,19 @@
 #include <boost/filesystem/exception.hpp>
 
 #include "chunkserver-common/disk_plugin.h"
+#include "chunkserver-common/disk_utils.h"
 #include "slogger/slogger.h"
+
+namespace {
+
+/// An hdd.cfg selector holds nothing else, so any other prefix is unreachable.
+bool isUsableDiskPrefix(const std::string &prefix) {
+	return !prefix.empty() &&
+	       prefix.find_first_not_of(disk::kDiskPrefixCharacters) ==
+	           std::string::npos;
+}
+
+}  // namespace
 
 bool PluginManager::loadPlugins(const std::string &directory) {
 	try {
@@ -65,10 +77,32 @@ bool PluginManager::loadPlugins(const std::string &directory) {
 
 				if (!checkVersion(plugin.get())) { continue; }
 
-				allPlugins_.insert(std::make_pair(plugin->name(), plugin));
-
 				boost::shared_ptr<DiskPlugin> diskPlugin =
 				    boost::dynamic_pointer_cast<DiskPlugin>(plugin);
+
+				// Both rejections happen before any registration, so a plugin
+				// that cannot serve a prefix is never advertised, reloaded or
+				// cleaned up as a loaded one.
+				if (diskPlugin != nullptr &&
+				    !isUsableDiskPrefix(diskPlugin->prefix())) {
+					safs::log_warn(
+					    "Ignoring plugin {}: '{}' is not a usable hdd.cfg prefix",
+					    plugin->name(), diskPlugin->prefix());
+					continue;
+				}
+
+				// Load order follows directory enumeration, so name the winner
+				// rather than leaving the choice silent.
+				if (diskPlugin != nullptr &&
+				    diskPlugins_.count(diskPlugin->prefix()) > 0) {
+					safs::log_warn(
+					    "Ignoring plugin {}: prefix '{}' is already served by {}",
+					    plugin->name(), diskPlugin->prefix(),
+					    diskPlugins_.at(diskPlugin->prefix())->name());
+					continue;
+				}
+
+				allPlugins_.insert(std::make_pair(plugin->name(), plugin));
 
 				if (diskPlugin != nullptr) {
 					diskPlugins_.insert(std::make_pair(diskPlugin->prefix(),
@@ -93,6 +127,17 @@ IDisk *PluginManager::createDisk(const disk::Configuration &configuration) {
 	}
 
 	return nullptr;
+}
+
+std::string PluginManager::loadedDiskPrefixes() const {
+	std::string prefixes;
+
+	for (const auto &[prefix, plugin] : diskPlugins_) {
+		if (!prefixes.empty()) { prefixes += ", "; }
+		prefixes += prefix;
+	}
+
+	return prefixes.empty() ? "none" : prefixes;
 }
 
 void PluginManager::showLoadedPlugins() {

--- a/src/chunkserver/chunkserver-common/plugin_manager.h
+++ b/src/chunkserver/chunkserver-common/plugin_manager.h
@@ -21,6 +21,7 @@
 #include "common/platform.h"
 
 #include <map>
+#include <string>
 
 #include <boost/dll/import.hpp>
 #include <boost/filesystem.hpp>
@@ -45,6 +46,10 @@ public:
 
 	/// Shows information about the loaded plugins.
 	void showLoadedPlugins();
+
+	/// Returns the hdd.cfg prefixes a Disk plugin is loaded for, comma
+	/// separated, so an unresolved prefix can be reported against them.
+	std::string loadedDiskPrefixes() const;
 
 	/// True if this plugin manager can handle the plugin based on the version.
 	bool checkVersion(IPlugin *plugin);

--- a/src/chunkserver/disk_unittest.cc
+++ b/src/chunkserver/disk_unittest.cc
@@ -93,6 +93,81 @@ TEST(DiskTests, ParseZonedHddLine) {
 	ASSERT_FALSE(diskConfig2.isValid);
 }
 
+TEST(DiskTests, ParsePluginPrefixHddLine) {
+	// A non-zonefs prefix selects a plugin serving a conventional device, so a
+	// single path is enough.
+	const disk::Configuration diskConfig("leil_cmr:/mnt/hdd_35");
+
+	ASSERT_TRUE(diskConfig.isValid);
+	ASSERT_FALSE(diskConfig.isZoned);
+	ASSERT_EQ(diskConfig.prefix, "leil_cmr");
+	ASSERT_EQ(diskConfig.metaPath, "/mnt/hdd_35/");
+	ASSERT_EQ(diskConfig.dataPath, "/mnt/hdd_35/");
+
+	// The removal marker is stripped before the prefix is read.
+	const disk::Configuration removedDisk("*leil_cmr:/mnt/hdd_35");
+
+	ASSERT_TRUE(removedDisk.isValid);
+	ASSERT_TRUE(removedDisk.isMarkedForRemoval);
+	ASSERT_EQ(removedDisk.prefix, "leil_cmr");
+}
+
+TEST(DiskTests, ParseHddLineWithoutPluginPrefix) {
+	// A bare path has no prefix and is served by the built-in CmrDisk.
+	const disk::Configuration plainPath("/mnt/hdd_35");
+
+	ASSERT_TRUE(plainPath.isValid);
+	ASSERT_TRUE(plainPath.prefix.empty());
+	ASSERT_FALSE(plainPath.isZoned);
+
+	// A colon inside a path is not a prefix separator: the path starts with a
+	// character that cannot appear in a prefix.
+	const disk::Configuration colonInPath("/mnt/hdd:35/meta");
+
+	ASSERT_TRUE(colonInPath.isValid);
+	ASSERT_TRUE(colonInPath.prefix.empty());
+	ASSERT_EQ(colonInPath.metaPath, "/mnt/hdd:35/meta/");
+
+	// A relative path with no colon at all is not a prefix either.
+	const disk::Configuration relativePath("hdd_35");
+
+	ASSERT_TRUE(relativePath.isValid);
+	ASSERT_TRUE(relativePath.prefix.empty());
+
+	// A relative path whose first component holds a colon needs the "./"
+	// escape, since '.' cannot start a prefix.
+	const disk::Configuration escapedPath("./archive:01");
+
+	ASSERT_TRUE(escapedPath.isValid);
+	ASSERT_TRUE(escapedPath.prefix.empty());
+	ASSERT_EQ(escapedPath.metaPath, "./archive:01/");
+
+	// Without the escape its first component is read as a plugin name.
+	const disk::Configuration ambiguousPath("archive:01");
+
+	ASSERT_TRUE(ambiguousPath.isValid);
+	ASSERT_EQ(ambiguousPath.prefix, "archive");
+}
+
+TEST(DiskTests, ParseHddLineWithoutPaths) {
+	// A selector with nothing after it is invalid, not an empty path.
+	const disk::Configuration onlyPrefix("leil_cmr:");
+
+	ASSERT_FALSE(onlyPrefix.isValid);
+	ASSERT_FALSE(onlyPrefix.isComment);
+	ASSERT_FALSE(onlyPrefix.isEmpty);
+
+	// Same for a line holding nothing but the removal marker.
+	const disk::Configuration onlyRemovalMarker("*");
+
+	ASSERT_FALSE(onlyRemovalMarker.isValid);
+
+	// A delimiter with nothing before it leaves no metadata path.
+	const disk::Configuration emptyMetaPath("leil_cmr: | /mnt/data");
+
+	ASSERT_FALSE(emptyMetaPath.isValid);
+}
+
 TEST(DiskTests, UpdateChunkAttributesRetrySucceedsAfterTransientErrors) {
 	const disk::Configuration diskConfig("/mnt/hdd_22/");
 	FlakyAttributesDisk disk(diskConfig);

--- a/src/chunkserver/hddspacemgr.cc
+++ b/src/chunkserver/hddspacemgr.cc
@@ -1367,15 +1367,15 @@ enum class ChunkCopyResult : std::uint8_t { Ok, ReadFailed, WriteFailed };
 /// reusing the source CRCs in \a sourceCrcData (reads decompress, so they
 /// still describe the copied bytes) and updating \a dupCrcData.
 ///
-/// Both formats copy in batches of kChunkCopyBatchBlocks: zoned destinations
-/// through writeChunkBlocks(), the rest appending to the caller's data seek
-/// through writeChunkData().
+/// Both formats copy in batches of kChunkCopyBatchBlocks: destinations that map
+/// blocks themselves through writeChunkBlocks(), the rest appending to the
+/// caller's data seek through writeChunkData().
 static ChunkCopyResult hddCopyChunkBlocks(IChunk *sourceChunk, IChunk *dupChunk,
                                           uint16_t blockCount, const uint8_t *sourceCrcData,
                                           uint8_t *dupCrcData, const char *errorMsg) {
 	IDisk *sourceDisk = sourceChunk->owner();
 	IDisk *dupDisk = dupChunk->owner();
-	const bool isZonedDestination = dupDisk->isZonedDevice();
+	const bool destinationMapsBlocksItself = !dupDisk->hasImplicitBlockOffsets();
 
 	// Pooled, so repeated duplications reuse the allocation; zone reads are
 	// O_DIRECT straight into it, hence the buffer's IO alignment.
@@ -1414,7 +1414,7 @@ static ChunkCopyResult hddCopyChunkBlocks(IChunk *sourceChunk, IChunk *dupChunk,
 			DiskWriteStatsUpdater updater(dupDisk, batchSize);
 			int written = 0;
 
-			if (isZonedDestination) {
+			if (destinationMapsBlocksItself) {
 				crcs.resize(blocksInBatch);
 				for (uint16_t i = 0; i < blocksInBatch; i++) {
 					const uint8_t *crcPointer =
@@ -1693,7 +1693,8 @@ static int finishTruncatedCopy(ChunkCopyGuard &guard, IChunk *sourceChunk, IChun
 			       kCrcSize);
 		}
 
-		if (copyDisk->ftruncateData(copy, copy->getFileSizeFromBlockCount(blocks)) < 0) {
+		if (copyDisk->hasImplicitBlockOffsets() &&
+		    copyDisk->ftruncateData(copy, copy->getFileSizeFromBlockCount(blocks)) < 0) {
 			hddAddErrorAndPreserveErrno(copy);
 			safs::log_warn_with_error_code(errno, "{}: file:{} - ftruncate error", errorMsg,
 			                               copy->fullMetaFilename());
@@ -1737,7 +1738,7 @@ static int finishTruncatedCopy(ChunkCopyGuard &guard, IChunk *sourceChunk, IChun
 	{
 		DiskWriteStatsUpdater updater(copyDisk, SFSBLOCKSIZE);
 
-		if (copyDisk->isZonedDevice()) {
+		if (!copyDisk->hasImplicitBlockOffsets()) {
 			retSize = copyDisk->writeChunkBlock(copy, copy->version(), block, 0, SFSBLOCKSIZE, crc,
 			                                    buffers.copyCrc, blockBuffer) == SAUNAFS_STATUS_OK
 			              ? SFSBLOCKSIZE
@@ -1979,6 +1980,10 @@ static int hddInternalTruncate(uint64_t chunkId, ChunkPartType chunkType,
 	// step 2. truncate
 	blocks = ((length + SFSBLOCKSIZE - 1) / SFSBLOCKSIZE);
 
+	// A Disk that maps blocks itself owns its data layout, so its data file is
+	// never cut to a logical length: shrinkToBlocks() drops the blocks instead.
+	const bool diskMapsBlocksItself = !disk->hasImplicitBlockOffsets();
+
 	if (blocks > chunk->blocks()) {  //Expanding
 		// Fill new blocks with empty CRC
 		uint8_t *crcData = gOpenChunks.getResource(chunk->metaFD()).crcData();
@@ -1987,7 +1992,8 @@ static int hddInternalTruncate(uint64_t chunkId, ChunkPartType chunkType,
 		}
 
 		// Do the actual truncation to the aligned block size
-		if (disk->ftruncateData(chunk,
+		if (!diskMapsBlocksItself &&
+		    disk->ftruncateData(chunk,
 		                        chunk->getFileSizeFromBlockCount(blocks)) < 0) {
 			hddAddErrorAndPreserveErrno(chunk);
 			safs_silent_errlog(LOG_WARNING,
@@ -2004,7 +2010,7 @@ static int hddInternalTruncate(uint64_t chunkId, ChunkPartType chunkType,
 		if (lastPartialBlockSize > 0) {
 			auto len = chunk->getFileSizeFromBlockCount(fullBlocks) +
 			           lastPartialBlockSize;
-			if (disk->ftruncateData(chunk, len) < 0) {
+			if (!diskMapsBlocksItself && disk->ftruncateData(chunk, len) < 0) {
 				hddAddErrorAndPreserveErrno(chunk);
 				safs_silent_errlog(LOG_WARNING,
 				    "truncate: file:%s - ftruncate error",
@@ -2015,7 +2021,8 @@ static int hddInternalTruncate(uint64_t chunkId, ChunkPartType chunkType,
 			}
 		}
 
-		if (disk->ftruncateData(chunk,
+		if (!diskMapsBlocksItself &&
+		    disk->ftruncateData(chunk,
 		                        chunk->getFileSizeFromBlockCount(blocks)) < 0) {
 			hddAddErrorAndPreserveErrno(chunk);
 			safs_silent_errlog(LOG_WARNING,
@@ -2027,15 +2034,17 @@ static int hddInternalTruncate(uint64_t chunkId, ChunkPartType chunkType,
 		}
 
 		// remove unneeded blocks
-		if (disk->isZonedDevice()) {
+		if (diskMapsBlocksItself) {
 			chunk->shrinkToBlocks(static_cast<uint16_t>(blocks));
 		}
 
 		if (lastPartialBlockSize > 0) {
 			auto offset = chunk->getBlockOffset(fullBlocks);
 
+			// The trailing block cannot be cut in place, so it is read whole,
+			// zero-filled past the new length and written back below.
 			auto toBeRead =
-			    disk->isZonedDevice() ? SFSBLOCKSIZE : lastPartialBlockSize;
+			    diskMapsBlocksItself ? SFSBLOCKSIZE : lastPartialBlockSize;
 
 			{
 				DiskReadStatsUpdater updater(disk, toBeRead);
@@ -2056,7 +2065,7 @@ static int hddInternalTruncate(uint64_t chunkId, ChunkPartType chunkType,
 
 			HddStats::overheadRead(toBeRead);
 
-			if (disk->isZonedDevice()) {
+			if (diskMapsBlocksItself) {
 				memset(blockBuffer + lastPartialBlockSize, 0,
 				       SFSBLOCKSIZE - lastPartialBlockSize);
 			}
@@ -2071,14 +2080,14 @@ static int hddInternalTruncate(uint64_t chunkId, ChunkPartType chunkType,
 			uint8_t *crData = gOpenChunks.getResource(chunk->metaFD()).crcData();
 			memcpy(crData + fullBlocks * kCrcSize, crcBuff, kCrcSize);
 
-			uint32_t jump = disk->isZonedDevice() ? 2 : 1;
+			uint32_t jump = diskMapsBlocksItself ? 2 : 1;
 
 			for (auto block = fullBlocks + jump; block < originalBlocks;
 			     block++) {
 				memcpy(crData + block * kCrcSize, &gEmptyBlockCrc, kCrcSize);
 			}
 
-			if (disk->isZonedDevice()) {
+			if (diskMapsBlocksItself) {
 				{
 					DiskWriteStatsUpdater updater(disk, SFSBLOCKSIZE);
 
@@ -2185,12 +2194,13 @@ static int hddInternalDuplicateTruncate(uint64_t chunkId, uint32_t chunkVersion,
 	const uint16_t blocks =
 	    static_cast<uint16_t>((copyChunkLength + SFSBLOCKSIZE - 1) / SFSBLOCKSIZE);
 
-	// Seek to the beginning of data block on both chunks
-	if (!dupDisk->isZonedDevice()) {
+	// Seek to the beginning of data block on both chunks. A Disk that maps
+	// blocks itself has no meaningful data-file cursor, so it is left alone.
+	if (dupDisk->hasImplicitBlockOffsets()) {
 		dupDisk->lseekData(dupChunk, dupChunk->getBlockOffset(0), SEEK_SET);
 	}
 
-	if (!origDisk->isZonedDevice()) {
+	if (origDisk->hasImplicitBlockOffsets()) {
 		origDisk->lseekData(originalChunk, originalChunk->getBlockOffset(0),
 		                    SEEK_SET);
 	}

--- a/tests/install-packages.sh
+++ b/tests/install-packages.sh
@@ -85,6 +85,7 @@ apt_packages=(
 	libtirpc-dev
 	liburcu-dev
 	libyaml-cpp-dev
+	libzstd-dev
 	netcat-openbsd
 	python3-venv
 	uuid-dev
@@ -124,6 +125,7 @@ dnf_packages=(
 	libibverbs-utils    # ibv_devices / ibv_devinfo (NFS/RDMA Ganesha test)
 	libnsl
 	libtirpc-devel
+	libzstd-devel
 	netcat
 	pam-devel
 	pkgconfig


### PR DESCRIPTION
## Summary

The chunkserver supports disk plugins but only ever supported *one*. Three
assumptions had hardened around the zoned plugin being the only one, and this PR
undoes all three. No disk that exists today changes how it stores or serves data.

**Configuration.** A line was recognised as belonging to a plugin only if it
began with the one prefix the parser knew by name, and dispatch keyed on whether
the device was *zoned* rather than on whether it named a plugin at all. Those
questions are now separate: any prefix decides who owns the disk, and being zoned
is one plugin's property — so the zoned requirement of separate metadata and data
locations is unchanged. The grammar is narrow: the character set excludes path
separators and the colon must follow immediately, so an absolute path is never
read as a prefix. A relative path is the one ambiguous case, when its first
component is made only of prefix characters and contains a colon; a leading `./`
disambiguates it, and the manual page says so. The manual page and the plugin
interface both described the prefixed form as zoned-device syntax; both now
describe the general grammar.

**Data layout.** The "is this zoned" predicate had accumulated four unrelated
jobs. Only one concerned stored data: whether the Nth block sits at the Nth
block-sized offset, which is what lets the chunkserver compute offsets itself,
truncate to a logical length and append raw bytes instead of using a disk's
block-level interface. That is false for zoned devices, but there is nothing
about zones in it — any disk managing its own placement breaks it. It now has its
own predicate, answered by default in terms of the old one, and the copy,
truncate and duplicate-truncate paths ask it instead. The remaining uses are
genuinely zone matters: read-ahead, cache advice, trash registration, post-scan
reconstruction, collector eligibility.

Data-file truncation is gated on the same predicate. It used to be called
unconditionally, and the core relied on a self-managing plugin ignoring it; that
the zoned plugin does ignore it is a property of that plugin, not of the
interface. The calls now skipped for it were exactly the ones it was already
discarding.

This has to live in the chunkserver: shrinking a chunk to a length inside a block
relies on the data file being cut mid-block, and a disk that cannot be cut that
way needs the read-clear-rewrite branch instead — which a plugin cannot override
its way into.

**Compression support.** The Zstandard wrapper sat inside the zoned plugin though
nothing in it is zone-specific — one frame per block plus per-chunk dictionary
bookkeeping. A second copy is how two compressed formats quietly stop being
mutually readable, so it now belongs to the core, with the library resolved once.
The implementation is untouched. It does become a dependency of the chunkserver
rather than of one plugin, so the lookup falls back from packaged CMake
description to pkg-config to a plain search, and the packaging metadata, the test
machine installer and the source build instructions all list it.

The last commit fixes something that predates all of this. A configuration line
that throws escapes the parse loop, which skips the step restoring the flag that
gates disk maintenance — leaving a running chunkserver with no scanning, no space
refresh, no damaged-disk detection and no disk removal until a later reload
succeeds. Restoring that flag alone would be worse than the disease: the loop
also marks every disk as gone before parsing, so maintenance would resume and
act on those marks. Both are now undone together, so a failed reload leaves the
previous configuration standing.

## Consequences

Configuration errors that used to pass or crash are now reported. A line naming
a plugin that is not loaded is rejected, naming the unresolved prefix and the
prefixes a plugin was loaded for; a line that leaves no path once its markers
are removed is reported as invalid rather than throwing out of range — two such
lines terminate the chunkserver on `dev` today, since that exception is not the
type the callers catch.

Neither aborts startup. The error is logged, the rest of the file is not read,
and the chunkserver continues with the disks configured by the lines above it.
That is the pre-existing behaviour for every configuration error and this PR does
not change it, but the manual page previously claimed otherwise and the wording
is corrected.

Changing the plugin that serves a path is no longer a reload. Disks are matched
by path and do not record which plugin created them, so an edited prefix used to
be accepted and then ignored, leaving the previous implementation in place. It
now fails the reload and takes a restart. The failure is contained: nothing below
the edited line is applied, and the configuration in force before it stands.

A plugin whose prefix no configuration line could name, or whose prefix another
plugin already serves, is ignored at load with a warning rather than registered.

The disk interface gained a method, so plugins built against an earlier revision
must be rebuilt — the load-time version check compares releases and won't catch
an interface that changed shape within one.

## Deliberately left open

Whether two plugins claiming the same prefix should be fatal. First loaded wins,
which is what the underlying container already did, and the collision is now
logged naming both plugins — but refusing to start might be the better answer.
That depends on how plugins end up being shipped and versioned, which is not
settled, and it cannot happen while only one plugin exists.

Whether an unusable hdd.cfg should stop the chunkserver rather than let it run
with a partial disk set. It should, but the handler covers every configuration
error, so making it fatal changes startup for deployments that have nothing to do
with plugins. That is a deliberate behaviour change and wants its own release
note.

## Tests

New unit tests cover the configuration grammar: a prefixed line, a prefixed line
marked for removal, an unprefixed path, a path containing a colon, a relative
path, the `./` escape and the ambiguous form it escapes, and the three malformed
lines that previously threw — a bare selector, a bare removal marker, and a
selector followed only by a delimiter.

Three things are not covered by unit tests, because they need state this suite
does not build: the reload identity check and the reload rollback both need a
populated disk list, and the plugin registration rejections need a loaded shared
object.

Worth stating plainly: nothing in tree produces the combination the layout
predicate exists to express — a disk that is not zoned and still maps its own
blocks — so the changed copy and truncate branches are exercised only as zoned
behaviour. The SMR suite is what currently guards them.
