### PR TITLE
ci: set buildDiscarder to limit the number of builds to keep

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -247,7 +247,7 @@ pipeline {
     options {
         skipStagesAfterUnstable()
         // TODO: Add more lenient rules for dev
-        buildDiscarder(logRotator(artifactDaysToKeepStr: "7", artifactNumToKeepStr: "2"))
+        buildDiscarder(logRotator(numToKeepStr: '70', artifactDaysToKeepStr: "7", artifactNumToKeepStr: "2"))
         parallelsAlwaysFailFast()
     }
     tools { go '1.22.2' }


### PR DESCRIPTION
Added numToKeepStr parameter for buildDiscarder to limit retained builds to 70 in order to reduce disk usage.