### PR TITLE
chore: bump version to v5.13.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,7 +73,7 @@ if(ENABLE_CCACHE AND CCACHE_FOUND)
   message(STATUS "Using ccache")
 endif()
 
-set(DEFAULT_MIN_VERSION "5.12.0")
+set(DEFAULT_MIN_VERSION "5.13.0")
 
 include(GNUInstallDirs)
 


### PR DESCRIPTION
Work in this cycle adds packets to the chunkserver registration exchange. A node must be able to tell whether the peer it just connected to understands them, and that test is a comparison against the release version, so the target release advances to give the comparison a number to use.

The gate itself arrives with the feature. This commit only moves the number, so a build from this point reports v5.13.0.

Related to: LS-1075