### PR TITLE
fix(cs): drop job replies to a dead connection

### DIFF
--- a/src/chunkserver/master_connection.cc
+++ b/src/chunkserver/master_connection.cc
@@ -54,6 +54,7 @@
 static constexpr uint32_t kMaxBackgroundJobsThreshold = (kMaxBackgroundJobsCount * 9) / 10;
 
 MasterConn::~MasterConn() {
+	*callbackActive_ = false;
 	if (socketFD_ >= 0) { tcpclose(socketFD_); }
 }
 
@@ -911,7 +912,12 @@ void MasterConn::replicateChunk(const std::vector<uint8_t> &data) {
 
 std::function<void(uint8_t status, void *packet)> MasterConn::sauJobFinishedAndLock(
     MasterConn *masterConn, uint64_t chunkId, ChunkPartType chunkType) {
-	return [masterConn, chunkId, chunkType](uint8_t status, void *packet) {
+	return [masterConn, chunkId, chunkType, active = masterConn->callbackActive_](uint8_t status,
+	                                                                              void *packet) {
+		if (!*active) {
+			deletePacket(packet);
+			return;
+		}
 		// The original job's output packet is sent as the response to the master's request
 		masterConn->sauJobFinished(status, packet);
 
@@ -935,8 +941,13 @@ std::function<void(uint8_t status, void *packet)> MasterConn::sauJobFinishedAndL
 
 std::function<void(uint8_t status, void *packet)> MasterConn::sauJobFinished(
     MasterConn *masterConn) {
-	return
-	    [masterConn](uint8_t status, void *packet) { masterConn->sauJobFinished(status, packet); };
+	return [masterConn, active = masterConn->callbackActive_](uint8_t status, void *packet) {
+		if (*active) {
+			masterConn->sauJobFinished(status, packet);
+		} else {
+			deletePacket(packet);
+		}
+	};
 }
 
 void MasterConn::sauJobFinished(uint8_t status, void *packet) {

--- a/src/chunkserver/master_connection.h
+++ b/src/chunkserver/master_connection.h
@@ -185,9 +185,14 @@ public:
 	RegistrationStatus registrationStatus() const { return registrationStatus_; }
 
 	void setMode(ConnectionMode newMode) {
+		// A new socket gets a new flag, so replies owed to the previous one stay disarmed.
+		if (newMode == ConnectionMode::CONNECTED && mode_ != newMode) {
+			callbackActive_ = std::make_shared<bool>(true);
+		}
 		mode_ = newMode;
 
 		if (mode_ == ConnectionMode::KILL) {  // The socket will be closed soon.
+			*callbackActive_ = false;
 			registrationStatus_ = RegistrationStatus::kUnregistered;
 		}
 	}
@@ -242,6 +247,9 @@ private:
 	bool isVersionLessThan5_{false};    ///< Indicates if the master server is an old version.
 
 	ConnectionMode mode_{ConnectionMode::FREE};  ///< Current mode of the connection to this master.
+	/// Cleared when the socket dies, so a job finishing afterwards drops its reply instead of
+	/// writing it to whatever occupies this connection by then.
+	std::shared_ptr<bool> callbackActive_{std::make_shared<bool>(true)};
 	/// Registration status to this MDS.
 	RegistrationStatus registrationStatus_{RegistrationStatus::kUnregistered};
 	int socketFD_{-1};                           ///< Socket file descriptor for this connection.

--- a/src/chunkserver/master_connection_unittest.cc
+++ b/src/chunkserver/master_connection_unittest.cc
@@ -1,0 +1,79 @@
+/*
+   Copyright 2026 Leil Storage
+
+   This file is part of SaunaFS.
+
+   SaunaFS is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, version 3.
+
+   SaunaFS is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with SaunaFS. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "common/platform.h"
+
+#include <gtest/gtest.h>
+#include <memory>
+#include <vector>
+
+#include "chunkserver/bgjobs.h"
+#include "chunkserver/master_connection.h"
+#include "common/slice_traits.h"
+#include "protocol/cstoma.h"
+
+TEST(MasterConnectionTests, DropsReplyFromPreviousSocket) {
+	MasterConn connection("localhost", "9420", "default", nullptr, nullptr);
+	connection.setMode(ConnectionMode::CONNECTED);
+	auto callback = MasterConn::sauJobFinished(&connection);
+	auto *packet = new OutputPacket;
+	cstoma::createChunk::serialize(packet->packet, 123, slice_traits::standard::ChunkPartType(),
+	                               SAUNAFS_STATUS_OK);
+
+	connection.setMode(ConnectionMode::KILL);
+	connection.setMode(ConnectionMode::CONNECTED);
+	callback(SAUNAFS_STATUS_OK, packet);
+	EXPECT_TRUE(connection.isOutputQueueEmpty());
+}
+
+TEST(MasterConnectionTests, DropsLockReplyFromPreviousSocket) {
+	MasterConn connection("localhost", "9420", "default", nullptr, nullptr);
+	connection.setMode(ConnectionMode::CONNECTED);
+	auto callback = MasterConn::sauJobFinishedAndLock(&connection, 123,
+	                                                  slice_traits::standard::ChunkPartType());
+	auto *packet = new OutputPacket;
+	cstoma::createChunk::serialize(packet->packet, 123, slice_traits::standard::ChunkPartType(),
+	                               SAUNAFS_STATUS_OK);
+
+	connection.setMode(ConnectionMode::KILL);
+	connection.setMode(ConnectionMode::CONNECTED);
+	callback(SAUNAFS_ERROR_NOTDONE, packet);
+	EXPECT_TRUE(connection.isOutputQueueEmpty());
+}
+
+TEST(MasterConnectionTests, DestroyedConnectionDisarmsPendingReplies) {
+	// masterconn_term releases the connection first and the job pools second. Dropping the last
+	// pool reference runs the destructor, which flushes any status still queued into the callback
+	// that was owed the reply. That callback must not reach the connection that no longer exists.
+	//
+	// This is a sanitizer reproducer and it asserts nothing on a plain build: the fault it guards
+	// is a read of freed memory, which only a sanitizer turns into a failure. Run it under the
+	// asan preset to gate the behaviour; a green plain build says only that it did not crash.
+	std::vector<int> descriptors;
+	auto pool = std::make_shared<MasterJobPool>("term-test", 1, 10, 1, descriptors);
+	auto connection = std::make_unique<MasterConn>("localhost", "9420", "default", pool, nullptr);
+	connection->setMode(ConnectionMode::CONNECTED);
+
+	auto callback = MasterConn::sauJobFinished(connection.get());
+	auto *packet = new OutputPacket;
+	cstoma::createChunk::serialize(packet->packet, 123, slice_traits::standard::ChunkPartType(),
+	                               SAUNAFS_STATUS_OK);
+
+	connection.reset();
+	callback(SAUNAFS_STATUS_OK, packet);
+}


### PR DESCRIPTION
A background job can finish after the master connection that asked for it is gone: the socket was killed and a new one may already be connected, or masterconn_term has released the connection and the job pools flush their last completions afterwards. The reply was then queued on the next socket, or written through a dangling pointer, which AddressSanitizer reports as a heap-use-after-free at shutdown.

Found while giving the chunkserver one connection per metadata server: connections then come and go while their jobs are still in flight, and the review of that path showed the released code has the same fault on its single connection.

Each connected socket now arms a shared flag that both job callbacks capture. Leaving CONNECTED for KILL and destroying the connection clear it, so a late completion frees its packet instead of replying on behalf of a socket that no longer exists.

Related to: LS-1075