### PR TITLE
fix(mount): report why non-empty mountpoint fails

### DIFF
--- a/src/mount/fuse/main.cc
+++ b/src/mount/fuse/main.cc
@@ -157,6 +157,8 @@ int fuse_mnt_check_empty(const char *mnt, mode_t rootmode, off_t rootsize) {
 		struct dirent *ent;
 		DIR *dp = opendir(mnt);
 		if (!dp) {
+			fprintf(stderr, "failed to open mountpoint %s: %s\n",
+				mnt, strerror(errno));
 			return -1;
 		}
 		while ((ent = readdir(dp))) {
@@ -171,8 +173,11 @@ int fuse_mnt_check_empty(const char *mnt, mode_t rootmode, off_t rootsize) {
 		isempty = 0;
 	}
 
-	if (!isempty)
+	if (!isempty) {
+		fprintf(stderr, "mountpoint %s is not empty\n", mnt);
+		fprintf(stderr, "use '-o nonempty' if you are sure this is safe\n");
 		return -1;
+	}
 
 	return 0;
 }


### PR DESCRIPTION
fuse_mnt_check_empty() is a vendored copy of the libfuse helper with its diagnostics stripped. It returned a bare -1 both when opendir() failed and when the directory was not empty, and the caller turned that into exit(1) without printing anything. It was the only early-exit branch in main() with no message, so mounting over a non-empty directory looked like a silent failure.

Print the reason on stderr for both cases and point at the '-o nonempty' option. stderr is still connected at this point; the redirect to /dev/null happens later, in mainloop(), after fuse_session_mount() succeeds.

Close LS-789.